### PR TITLE
change shebang so it works with Termux:Widgets

### DIFF
--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 ##
 ## Script for managing proot'ed Linux distribution installations in Termux.
 ##


### PR DESCRIPTION
When trying to use `proot-distro login archlinux` in a shortcut I was getting this error:

`/data/data/com.termux/files/home/.shortcuts/startarch: /data/data/com.termux/files/usr/bin/proot-distro: /usr/bin/env: bad interpreter: No such file or directory

[Process completed (code 126) - press Enter]`

So I changed the shebang to the hardcoded location of bash. If we really want to use env, might I suggest the shebang provided by termux-fix-shebang? `!/data/data/com.termux/files/usr/bin/env bash`