### PR TITLE
Add --user flag

### DIFF
--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -755,11 +755,11 @@ command_login() {
 		# Fix this behavior by reporting a fake up-to-date kernel version.
 		set -- "--kernel-release=5.4.0-fake-kernel" "$@"
 
+		# If flag --user is specified
 		if [ -n "$user" ]; then
-			# If flag --user is specified
-			# Login as $user and set working directory to /home/$user
+			# Login as $user
+			# Home directory is inferred by su
 			set -- "--change-id=$user" "$@"
-			set -- "--cwd=/home/$user/" "$@"
 		else
 			# Default to root if --user is not specified
 			set -- "--cwd=/root" "$@"

--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -756,16 +756,9 @@ command_login() {
 		# Fix this behavior by reporting a fake up-to-date kernel version.
 		set -- "--kernel-release=5.4.0-fake-kernel" "$@"
 
-		# If flag --user is specified
-		if [ -n "$user" ]; then
-			# Login as $user
-			# Home directory is inferred by su
-			set -- "--change-id=$user" "$@"
-		else
-			# Default to root if --user is not specified
-			set -- "--cwd=/root" "$@"
-			set -- "--root-id" "$@"
-		fi
+		# Simulate root so we can switch users.
+		set -- "--cwd=/root" "$@"
+		set -- "--root-id" "$@"
 
 		# Core file systems that should always be present.
 		set -- "--bind=/dev" "$@"

--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -857,6 +857,7 @@ command_login_help() {
 	echo -e "  ${GREEN}--help               ${CYAN}- Show this help information.${RST}"
 	echo
 	echo -e "  ${GREEN}--user USER          ${CYAN}- Specify which user proot-distro should login to.${RST}"
+	echo -e "                         ${CYAN}If not provided, login defaults to root.{RST}"
 	echo
 	echo -e "  ${GREEN}--fix-low-ports      ${CYAN}- Modify bindings to protected ports to use${RST}"
 	echo -e "                         ${CYAN}a higher port number.${RST}"

--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -628,7 +628,8 @@ command_login() {
 	local fix_low_ports=false
 	local make_host_tmp_shared=false
 	local distro_name=""
-	local user=""
+	# Defaults to root if --user is not specified
+	local user="root"
 
 	while (($# >= 1)); do
 		case "$1" in


### PR DESCRIPTION
Allows specifying user to login to without running `su -` twice. (See discussion at #9 )

Defaults to root if flag is not provided to preserve compatibility.

Benefits:

- More intuitive
- Faster distro boot time
- Works with Ubuntu 18.04 (See #9 )

Example:
`proot-distro login ubuntu-18.04 --user myuser`