### PR TITLE
Enable -L flag in proot

### DIFF
--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -499,7 +499,7 @@ run_proot_cmd() {
 	fi
 
 	proot \
-		$qemu_arg \
+		$qemu_arg -L \
 		--kernel-release=5.4.0-faked \
 		--link2symlink \
 		--kill-on-exit \
@@ -1115,6 +1115,9 @@ command_login() {
 		# Some devices have old kernels and GNU libc refuses to work on them.
 		# Fix this behavior by reporting a fake up-to-date kernel version.
 		set -- "--kernel-release=5.4.0-faked" "$@"
+
+		# Fix lstat to prevent dpkg symlink size warnings
+		set -- "-L" "$@"
 
 		# Simulate root so we can switch users.
 		set -- "--cwd=/root" "$@"


### PR DESCRIPTION
Hi, i specified the `-L` flag in `proot-distro` script just to avoid dpkg failures when doing `apt-get update` when running legacy linux distributions like Ubuntu 14.04/Debian 8 (#58)

This also suppresses warnings about `dpkg` symlink size changed in newer distributions, prior to dpkg 1.18.6, 

About the `dpkg` symlink size changed output:
`dpkg warning: symbolic link size has changed from x to y`

Some references:
https://github.com/corbinlc/GNURootDebian/issues/103