### PR TITLE
Update distro versions

### DIFF
--- a/distro-build/alpine.sh
+++ b/distro-build/alpine.sh
@@ -1,5 +1,5 @@
 dist_name="Alpine Linux"
-dist_version="3.15.0"
+dist_version="3.17.0"
 
 bootstrap_distribution() {
 	for arch in aarch64 armv7 x86 x86_64; do

--- a/distro-build/archlinux.sh
+++ b/distro-build/archlinux.sh
@@ -1,5 +1,5 @@
 dist_name="Arch Linux"
-dist_version="2022.06.01"
+dist_version="2022.12.01"
 
 bootstrap_distribution() {
 	for arch in aarch64 armv7; do

--- a/distro-build/void.sh
+++ b/distro-build/void.sh
@@ -1,5 +1,5 @@
 dist_name="Void Linux"
-dist_version="20210316"
+dist_version="20221001"
 
 bootstrap_distribution() {
 	for arch in aarch64 armv7l i686 x86_64; do


### PR DESCRIPTION
Based on my testing these are very simple drop in updates.
No reason not to use them, especially on the rolling distros.