### PR TITLE
Added Void Linux musl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here are the supported distributions:
 * Manjaro AArch64
 * OpenSUSE (Tumbleweed)
 * Ubuntu (22.04)
-* Void Linux
+* Void Linux (glibc and musl)
 
 All systems come in a bare-minimum variant, typically consisting of package
 manager, shell, coreutils, util-linux and few more. Extended functionality

--- a/distro-build/void-musl.sh
+++ b/distro-build/void-musl.sh
@@ -1,0 +1,57 @@
+dist_name="Void Linux musl"
+dist_version="20221001"
+
+bootstrap_distribution() {
+	for arch in aarch64 armv7l x86_64; do
+		curl --fail --location \
+			--output "${WORKDIR}/void-musl-${arch}.tar.xz" \
+			"https://alpha.de.repo.voidlinux.org/live/${dist_version}/void-${arch}-musl-ROOTFS-${dist_version}.tar.xz"
+
+		sudo mkdir -m 755 "${WORKDIR}/void-musl-$(translate_arch "$arch")"
+		sudo tar -Jxp \
+			-f "${WORKDIR}/void-musl-${arch}.tar.xz" \
+			-C "${WORKDIR}/void-musl-$(translate_arch "$arch")"
+
+		cat <<- EOF | sudo unshare -mpf bash -e -
+		rm -f "${WORKDIR}/void-musl-$(translate_arch "$arch")/etc/resolv.conf"
+		echo "nameserver 1.1.1.1" > "${WORKDIR}/void-musl-$(translate_arch "$arch")/etc/resolv.conf"
+		mount --bind /dev "${WORKDIR}/void-musl-$(translate_arch "$arch")/dev"
+		mount --bind /proc "${WORKDIR}/void-musl-$(translate_arch "$arch")/proc"
+		mount --bind /sys "${WORKDIR}/void-musl-$(translate_arch "$arch")/sys"
+		chroot "${WORKDIR}/void-musl-$(translate_arch "$arch")" env SSL_NO_VERIFY_PEER=1 xbps-install -Suy xbps
+		chroot "${WORKDIR}/void-musl-$(translate_arch "$arch")" env SSL_NO_VERIFY_PEER=1 xbps-install -uy
+		chroot "${WORKDIR}/void-musl-$(translate_arch "$arch")" env SSL_NO_VERIFY_PEER=1 xbps-install -y base-minimal
+		chroot "${WORKDIR}/void-musl-$(translate_arch "$arch")" env SSL_NO_VERIFY_PEER=1 xbps-remove -y base-voidstrap
+		chroot "${WORKDIR}/void-musl-$(translate_arch "$arch")" env SSL_NO_VERIFY_PEER=1 xbps-reconfigure -fa
+		EOF
+
+		sudo rm -f "${WORKDIR}/void-musl-$(translate_arch "$arch")"/var/cache/xbps/* || true
+
+		sudo tar -J -c \
+			-f "${ROOTFS_DIR}/void-musl-$(translate_arch "$arch")-pd-${CURRENT_VERSION}.tar.xz" \
+			-C "$WORKDIR" \
+			"void-musl-$(translate_arch "$arch")"
+		sudo chown $(id -un):$(id -gn) "${ROOTFS_DIR}/void-musl-$(translate_arch "$arch")-pd-${CURRENT_VERSION}.tar.xz"
+	done
+}
+
+write_plugin() {
+	cat <<- EOF > "${PLUGIN_DIR}/void-musl.sh"
+	# This is a default distribution plug-in.
+	# Do not modify this file as your changes will be overwritten on next update.
+	# If you want customize installation, please make a copy.
+	DISTRO_NAME="Void Linux musl"
+
+	TARBALL_URL['aarch64']="${GIT_RELEASE_URL}/void-musl-aarch64-pd-${CURRENT_VERSION}.tar.xz"
+	TARBALL_SHA256['aarch64']="$(sha256sum "${ROOTFS_DIR}/void-musl-aarch64-pd-${CURRENT_VERSION}.tar.xz" | awk '{ print $1}')"
+	TARBALL_URL['arm']="${GIT_RELEASE_URL}/void-musl-arm-pd-${CURRENT_VERSION}.tar.xz"
+	TARBALL_SHA256['arm']="$(sha256sum "${ROOTFS_DIR}/void-musl-arm-pd-${CURRENT_VERSION}.tar.xz" | awk '{ print $1}')"
+	TARBALL_URL['x86_64']="${GIT_RELEASE_URL}/void-musl-x86_64-pd-${CURRENT_VERSION}.tar.xz"
+	TARBALL_SHA256['x86_64']="$(sha256sum "${ROOTFS_DIR}/void-musl-x86_64-pd-${CURRENT_VERSION}.tar.xz" | awk '{ print $1}')"
+
+	distro_setup() {
+	${TAB}# Set default shell to bash.
+	${TAB}run_proot_cmd usermod --shell /bin/bash root
+	}
+	EOF
+}


### PR DESCRIPTION
New file derived from void.sh, that allows the use of the musl libc for this distro on all architectures except i686 (not supported by Void Linux with musl).