### PR TITLE
feat/opensuse: lock filesystem package

### DIFF
--- a/distro-plugins/opensuse.sh
+++ b/distro-plugins/opensuse.sh
@@ -12,3 +12,8 @@ TARBALL_URL['i686']="https://github.com/termux/proot-distro/releases/download/v3
 TARBALL_SHA256['i686']="134690a6ad87ebeffac23419cbdd4e1963fc63cef580aa50bf4120c2756678fb"
 TARBALL_URL['x86_64']="https://github.com/termux/proot-distro/releases/download/v3.3.0/opensuse-x86_64-pd-v3.3.0.tar.xz"
 TARBALL_SHA256['x86_64']="6e3da2d841ccf4cb765b2b4ac7f4a7696281f75e7b95d728a2e267d110ec12cd"
+
+distro_setup() {
+        # Lock package filesystem to remove issues regarding zypper dup
+        zypper al filesystem
+}


### PR DESCRIPTION
This is to remove the issue with `zypper dup`, where opensuse breaks the entire proot filesystem as it installs the new one
![Screenshot_2023-03-20-07-48-41-49](https://user-images.githubusercontent.com/83752061/226217490-432f5b69-7ef4-426d-a57e-1ddf597d9407.png)
![Screenshot_2023-03-20-07-48-47-47](https://user-images.githubusercontent.com/83752061/226217498-2490b3e5-89c9-4d39-9721-794fadf6d0bb.png)
