### PR TITLE
fedora 35 is updated to fedora 37, fedora 37 is 64bit only

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here are the supported distributions (alias: name):
 * `alpine`: Alpine Linux (edge)
 * `archlinux`: Arch Linux ARM
 * `debian`: Debian (stable)
-* `fedora`: Fedora 35
+* `fedora`: Fedora 37 (AArch64 only)
 * `manjaro`: Manjaro (AArch64 only)
 * `opensuse`: OpenSUSE (Tumbleweed)
 * `pardus`: Pardus (yirmibir)


### PR DESCRIPTION
According to https://github.com/termux/proot-distro/pull/259