### PR TITLE
chore: remove TERM variable override

### DIFF
--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -700,7 +700,6 @@ command_install() {
 		MOZ_FAKE_NO_SANDBOX=1
 		PATH=${DEFAULT_PATH_ENV}
 		PULSE_SERVER=127.0.0.1
-		TERM=${TERM-xterm-256color}
 		TMPDIR=/tmp
 		EOF
 
@@ -1780,7 +1779,6 @@ command_login() {
 		"${login_env_vars[@]}" \
 		"COLORTERM=${COLORTERM-}" \
 		"HOME=${login_home}" \
-		"TERM=${TERM-xterm-256color}" \
 		"${login_shell}" \
 		"-l" \
 		"$@"


### PR DESCRIPTION
Not sure why TERM variable is being set explicitly here, but it conflicts with `tmux` (and probably other similar tools), because it doesn't allow such tools to set their `tmux-256color` TERM, resulting in improperly working applications like neovim.