### PR TITLE
Fix handling of custom DISTRO_ARCH parameter

### DIFF
--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -847,9 +847,10 @@ run_proot_cmd() {
 		case "$DISTRO_ARCH" in
 			aarch64) cpu_emulator_path="@TERMUX_PREFIX@/bin/qemu-aarch64";;
 			arm)
-				if [ "$DEVICE_CPU_ARCH" != "aarch64" ]; then
+				#TODO: improve detection, some aarch64 CPU don't support 32bit arm instuctions
+				#if [ "$DEVICE_CPU_ARCH" != "aarch64" ]; then
 					cpu_emulator_path="@TERMUX_PREFIX@/bin/qemu-arm"
-				fi
+				#fi
 				;;
 			i686)
 				if [ "$DEVICE_CPU_ARCH" != "x86_64" ]; then
@@ -1939,11 +1940,12 @@ command_login() {
 		case "$target_arch" in
 			aarch64) cpu_emulator_path="@TERMUX_PREFIX@/bin/qemu-aarch64";;
 			arm)
-				if [ "$DEVICE_CPU_ARCH" != "aarch64" ]; then
+				#TODO: improve detection, some aarch64 CPU don't support 32bit arm instuctions
+				#if [ "$DEVICE_CPU_ARCH" != "aarch64" ]; then
 					cpu_emulator_path="@TERMUX_PREFIX@/bin/qemu-arm"
-				else
-					need_cpu_emulator=false
-				fi
+				#else
+				#	need_cpu_emulator=false
+				#fi
 				;;
 			i686)
 				if [ "$DEVICE_CPU_ARCH" != "x86_64" ]; then
@@ -2840,7 +2842,8 @@ case "$(uname -m)" in
 	armv7l|armv8l) DEVICE_CPU_ARCH="arm";;
 	*) DEVICE_CPU_ARCH=$(uname -m);;
 esac
-DISTRO_ARCH=$DEVICE_CPU_ARCH
+DISTRO_ARCH=${DISTRO_ARCH:-}
+if [ -z "$DISTRO_ARCH" ]; then DISTRO_ARCH="${DEVICE_CPU_ARCH}"; fi
 
 # Verify architecture if possible - avoid running under linux32 or similar.
 if [ -x "@TERMUX_PREFIX@/bin/dpkg" ]; then


### PR DESCRIPTION
Fix handling of custom DISTRO_ARCH parameter.
Disable assumption of aarch64 being compatible with arm 32bit when selecting DISTRO_ARCH as 'arm' on aarch64 machine.

Testing (on aarch64):
* Install proot-distro ubuntu without custom DISTRO_ARCH:
  1. Install proot-distro ubuntu `proot-distro install ubuntu`
  2. Login `proot-distro login ubuntu`
  3. Check architecture in dpkg `dpkg --print-architecture`
    Should return: `arm64` in my case, or your native arch

Remove it before proceeding `proot-distro remove ubuntu`

* Install proot-distro ubuntu with custom DISTRO_ARCH set to 'arm'
  1. Install proot-distro ubuntu `DISTRO_ARCH='arm' proot-distro install ubuntu`
  2. Login without DISTRO_ARCH `proot-distro login ubuntu`
    Get errors:
	  ```
	    proot error: POKEDATA workaround is not supported on AArch32
	    proot warning: ptrace(POKEDATA): I/O error
	    proot error: can't transfer load script: Bad address
	    ...
	    proot info: vpid 1: terminated with signal 6
	  ```
      (This is confirmation that some aarch64 cpus don't support 32 bit arm instructions, in my case its Mtk Dimensity 9300+, but M1 mac should be the same)
  3. Login with `DISTRO_ARCH='arm' proot-distro login ubuntu`
  4. Check architecture in dpkg `dpkg --print-architecture`
    Should return: `armhf`

Possible further improvements can be made:
* caching DISTRO_ARCH to not specify it after first installation;
* improve detection of arm32 instruction support of aarch64 CPU, to disable emulation if not needed;
* addition of extra qemu user mode arguments, just as `-cpu` as per [Linux User space emulator - Command line options](https://www.qemu.org/docs/master/user/main.html#command-line-options)

Please share your opinion.