### PR TITLE
chore: Perform usr merge on deepin rootfs

### DIFF
--- a/distro-build/deepin.sh
+++ b/distro-build/deepin.sh
@@ -13,6 +13,7 @@ bootstrap_distribution() {
 			"https://github.com/deepin-community/deepin-rootfs/raw/master/deepin.gpg"
 
 		sudo mmdebstrap \
+			--hook-dir=/usr/share/mmdebstrap/hooks/merged-usr \
 			--keyring "${WORKDIR}/deepin-keyring.gpg" \
 			--architectures=${arch} \
 			--variant=minbase \


### PR DESCRIPTION
deepin rootfs has not merged usr, so it is not possible to install packages like dbus