### PR TITLE
pd-login: option to suppress cpu arch warning

### DIFF
--- a/proot-distro.sh
+++ b/proot-distro.sh
@@ -1408,6 +1408,7 @@ command_login() {
 	local no_link2symlink=false
 	local no_sysvipc=false
 	local no_kill_on_exit=false
+	local no_arch_warning=false
 	local login_user="root"
 	local login_wd=""
 	local -a login_env_vars
@@ -1464,6 +1465,9 @@ command_login() {
 				;;
 			--no-kill-on-exit)
 				no_kill_on_exit=true
+				;;
+			--no-arch-warning)
+				no_arch_warning=true
 				;;
 			--user)
 				if [ $# -ge 2 ]; then
@@ -1790,7 +1794,7 @@ command_login() {
 		fi
 	else
 		# Warn about CPU not supporting 32-bit instructions
-		if ! $SUPPORT_32BIT; then
+		if ! $no_arch_warning && ! $SUPPORT_32BIT; then
 			msg "${BRED}Warning: CPU doesn't support 32-bit instructions, some software may not work.${RST}"
 		fi
 	fi
@@ -2032,6 +2036,9 @@ command_login_help() {
 	msg "  ${GREEN}--no-kill-on-exit    ${CYAN}- Wait until all running processes will finish${RST}"
 	msg "                         ${CYAN}before exiting. This will cause proot to${RST}"
 	msg "                         ${CYAN}freeze if you are running daemons.${RST}"
+	msg
+	msg "  ${GREEN}--no-arch-warning     ${CYAN}- Suppress warning about CPU not supporting 32-bit${RST}"
+	msg "                         ${CYAN}instructions.${RST}"
 	msg
 	msg "  ${GREEN}--kernel [string]    ${CYAN}- Set the kernel release and compatibility${RST}"
 	msg "                         ${CYAN}level to string.${RST}"


### PR DESCRIPTION
Modern CPUs are not compatible with the ARM32 architecture. For scenarios where `proot-distro login` is invoked multiple times within a script, the warning message is frequently displayed. This commit introduces an option to suppress the warning.