### PR TITLE
alpine.sh: bump again due to cert issue, according to alpine linux blog.

### DIFF
--- a/distro-build/alpine.sh
+++ b/distro-build/alpine.sh
@@ -1,5 +1,5 @@
 dist_name="Alpine Linux"
-dist_version="3.21.0"
+dist_version="3.21.2"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/alpine-*.tar.xz


### PR DESCRIPTION
"These releases include a regression fix for [ca-certificates](https://gitlab.alpinelinux.org/alpine/ca-certificates/-/issues/6)."
- https://alpinelinux.org/posts/Alpine-3.18.11-3.19.6-3.20.5-3.21.2-released.html