### PR TITLE
alpine.sh: bump to 3.21.3

### DIFF
--- a/distro-build/alpine.sh
+++ b/distro-build/alpine.sh
@@ -1,5 +1,5 @@
 dist_name="Alpine Linux"
-dist_version="3.21.2"
+dist_version="3.21.3"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/alpine-*.tar.xz


### PR DESCRIPTION
It has security fix for musl libc.
https://alpinelinux.org/posts/Alpine-3.18.12-3.19.7-3.20.6-3.21.3-released.html