### PR TITLE
Fix gdkpixbuf2 bug in archlinux

### DIFF
--- a/distro-plugins/archlinux.sh
+++ b/distro-plugins/archlinux.sh
@@ -30,4 +30,5 @@ distro_setup() {
 		"https://github.com/Welpyes/gdk-pixbuf2-git/releases/download/2.48.10/gdk-pixbuf2-custom-2.42.10-1-aarch64.pkg.tar.xz"
 	run_proot_cmd pacman -U --noconfirm /tmp/gdk-pixbuf2-custom.pkg.tar.xz
 	run_proot_cmd rm /tmp/gdk-pixbuf2-custom.pkg.tar.xz
+	run_proot_cmd gdk-pixbuf-query-loaders --update-cache
 }


### PR DESCRIPTION
this fixes the errors when launching gtk applications in archlinux.
this also happens in artix but i havent tested the fix yet there, it should work but its untested.

this is what i used to fix and host it.
https://github.com/Welpyes/gdk-pixbuf2-git
its just a PKGBUILD with some modifications

this is the error:
```
❯ DISPLAY=:0 lxappearance

** (lxappearance:22699): WARNING **: 10:30:11.448: lxappearance.c:70: Failed to connect to the session message bus: Cannot spawn a message bus without a machine-id: Invalid machine ID in /var/lib/dbus/machine-id or /etc/machine-id

(lxappearance:22699): Gtk-WARNING **: 10:30:11.855: Could not load a pixbuf from /org/gtk/libgtk/icons/16x16/actions/help-about.png.
This may indicate that pixbuf loaders or the mime database could not be found.

(lxappearance:22699): Gtk-WARNING **: 10:30:11.856: Error loading theme icon 'help-about' for stock: Failed to load /org/gtk/libgtk/icons/16x16/actions/help-about.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.857: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.858: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.859: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.860: Error loading theme icon 'help-about' for stock: Failed to load /org/gtk/libgtk/icons/16x16/actions/help-about.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.861: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.862: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.863: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.864: Error loading theme icon 'window-close' for stock: Failed to load /org/gtk/libgtk/icons/16x16/actions/window-close.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.865: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.866: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.867: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.868: Error loading theme icon 'window-close' for stock: Failed to load /org/gtk/libgtk/icons/16x16/actions/window-close.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.869: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.870: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.871: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.872: Error loading theme icon 'gtk-apply' for stock: Failed to load /org/gtk/libgtk/icons/22x22/actions/gtk-apply.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.874: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.874: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.875: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.876: Error loading theme icon 'gtk-apply' for stock: Failed to load /org/gtk/libgtk/icons/22x22/actions/gtk-apply.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.878: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.878: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.879: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.885: Error loading theme icon 'go-previous' for stock: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.887: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/24x24/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.888: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.889: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.890: Error loading theme icon 'go-previous' for stock: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.892: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/24x24/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.892: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.893: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.895: Error loading theme icon 'go-next' for stock: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.896: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/24x24/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.897: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.898: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.899: Error loading theme icon 'go-next' for stock: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.900: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/24x24/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.901: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.901: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.902: Error loading theme icon 'process-stop' for stock: Failed to load /org/gtk/libgtk/icons/16x16/actions/process-stop.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.903: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/24x24/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.904: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.904: g_object_unref: assertion 'G_IS_OBJECT (object)' failed

(lxappearance:22699): Gtk-WARNING **: 10:30:11.905: Error loading theme icon 'process-stop' for stock: Failed to load /org/gtk/libgtk/icons/16x16/actions/process-stop.png: Unrecognized image file format

(lxappearance:22699): Gtk-WARNING **: 10:30:11.906: Error loading theme icon 'image-missing' for stock: Failed to load /org/gtk/libgtk/icons/24x24/status/image-missing.png: Unrecognized image file format

(lxappearance:22699): Gdk-CRITICAL **: 10:30:11.907: gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed

(lxappearance:22699): GLib-GObject-CRITICAL **: 10:30:11.908: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
**
Gtk:ERROR:../gtk/gtk/gtkiconhelper.c:495:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Bail out! Gtk:ERROR:../gtk/gtk/gtkiconhelper.c:495:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
zsh: IOT instruction  DISPLAY=:0 lxappearance
```