### PR TITLE
fix: remove /proc/self/fd bind to /dev/fd (issue 689)

### DIFF
--- a/proot_distro/commands/login/proot_cmd.py
+++ b/proot_distro/commands/login/proot_cmd.py
@@ -187,7 +187,6 @@ def _add_termux_dev_binds(args, rootfs):
     """Bind device files and fake /proc/sys substitutes used by Termux."""
     args += [
         "--bind=/dev/urandom:/dev/random",
-        "--bind=/proc/self/fd:/dev/fd",
     ]
     for i, name in ((0, "stdin"), (1, "stdout"), (2, "stderr")):
         if os.path.exists(f"/proc/self/fd/{i}"):

--- a/proot_distro/helpers/build_engine/run_step.py
+++ b/proot_distro/helpers/build_engine/run_step.py
@@ -176,7 +176,6 @@ def _exec_proot(engine, stage, command, stdin_input):
     if IS_TERMUX:
         proot_args += [
             "--bind=/dev/urandom:/dev/random",
-            "--bind=/proc/self/fd:/dev/fd",
         ]
         for i, name in ((0, "stdin"), (1, "stdout"), (2, "stderr")):
             if os.path.exists(f"/proc/self/fd/{i}"):


### PR DESCRIPTION
Remove /proc/self/fd bind to /dev/fd to fix <https://github.com/termux/proot-distro/issues/689>.

The existing bind mount: `--bind=/proc/self/fd:/dev/fd` causes failures such as missing /dev/fd/N entries during Bash process substitution (<(cmd)).

Removing the bind restores correct behavior by allowing /dev/fd to resolve through the expected procfs-backed mechanism.