### PR TITLE
search: return every installable image Docker Hub will serve (unlimited results)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ exporting it as a standalone OCI tarball.
    * [`install`](#install--install-a-container)
    * [`build`](#build--build-an-image-from-a-dockerfile)
    * [`push`](#push--push-a-built-image-to-a-registry)
+   * [`search`](#search--search-docker-hub-for-images)
    * [`login`](#login--start-a-shell-inside-a-container)
    * [`run`](#run--run-the-image-defined-entrypoint)
    * [`list`](#list--list-installed-containers)
@@ -518,6 +519,49 @@ upload must restart from zero.
 
 ---
 
+### `search` — Search Docker Hub for images
+
+```
+proot-distro search [OPTIONS] TERM
+```
+
+Queries Docker Hub's own repository search, mirroring `docker search`.
+The OCI Distribution specification has no standard search endpoint, so
+this works only against Docker Hub — the default registry — and not
+against self-hosted registries. No authentication is required, and the
+query never touches your local cache.
+
+| Option | Description |
+|---|---|
+| `--limit N` | Maximum number of results to return (default `25`). |
+| `-q`, `--quiet` | Print one bare repository name per line, ready to pipe into `install`. |
+| `-h`, `--help` | Show help for this command. |
+
+Results render as a NAME / DESCRIPTION / STARS / OFFICIAL / AUTOMATED /
+ARCH table that stacks onto two lines per result on terminals too narrow
+to align — mirroring the `list --image` layout. `OFFICIAL` and
+`AUTOMATED` are marked `[OK]`. The `ARCH` column lists the CPU
+architectures each image ships for, resolved by querying the
+repository's multi-arch manifest index; images whose `latest` tag is
+missing or single-architecture show `?`.
+
+Examples:
+
+```sh
+# Find images related to Ubuntu
+proot-distro search ubuntu
+
+# Top 5 results, bare names
+proot-distro search --limit 5 -q ubuntu
+
+# Search and install directly
+proot-distro search -q alpine | while read -r repo; do
+  proot-distro install "$repo" -n myalpine
+done
+```
+
+---
+
 ### `login` — Start a shell inside a container
 
 ```
@@ -564,7 +608,7 @@ proot-distro login ubuntu --get-proot-cmd
 | `-b`, `--bind SRC[:DST]` | Bind a custom path (repeatable). `SRC` is resolved via `os.path.abspath`. `DST`, when given, must be an absolute path (relative destinations are rejected). Overlap with an existing destination emits a warning but the bind is still added. |
 | `--emulator PATH` | Override the QEMU emulator binary for cross-arch containers. PATH must be executable. Only QEMU user-mode and Blink are known to work. |
 | `--kernel STRING` | Customize the kernel release string reported by `uname -r`. Default: `6.17.0-PRoot-Distro`. |
-| `--hostname STRING` | Customize the hostname inside the container. Default: `localhost`. |
+| `--hostname STRING` | Customize the hostname inside the container. Default: the container name. |
 | `-w`, `--work-dir PATH` | Set the initial working directory. Default: the user's home directory. |
 | `-e`, `--env VAR=VALUE` | Set an environment variable in the guest (repeatable). Wins over image-defined `Env` and the baseline defaults. |
 | `-d`, `--detach` | Start the session in the background and return to the prompt immediately. The session is daemonized (double-fork + `setsid`, detached from the controlling terminal) and its stdin/stdout/stderr are redirected to `/dev/null`, so output is discarded — redirect inside your own command if you need logs. A detached `login` with no `-- COMMAND` exits at once (the shell reads EOF). Track it with [`proot-distro ps`](#ps--list-active-sessions) and stop it with [`proot-distro kill`](#kill--stop-active-sessions). |

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ query never touches your local cache.
 
 | Option | Description |
 |---|---|
-| `--limit N` | Maximum number of results to return (default `25`). |
+| `--limit N` | Maximum number of results to return (default `100`; larger limits page through Docker Hub). |
 | `-q`, `--quiet` | Print one bare repository name per line, ready to pipe into `install`. |
 | `-h`, `--help` | Show help for this command. |
 

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ query never touches your local cache.
 
 | Option | Description |
 |---|---|
-| `--limit N` | Maximum number of results to return (default `100`; larger limits page through Docker Hub). |
+| `--limit N` | Maximum number of results to fetch from Docker Hub (default: unlimited — every repository the API will serve for the query). |
 | `-q`, `--quiet` | Print one bare repository name per line, ready to pipe into `install`. |
 | `-h`, `--help` | Show help for this command. |
 
@@ -543,9 +543,12 @@ Results render as a NAME / DESCRIPTION / STARS / OFFICIAL / AUTOMATED /
 ARCH table that stacks onto two lines per result on terminals too narrow
 to align — mirroring the `list --image` layout. `OFFICIAL` and
 `AUTOMATED` are marked `[OK]`. The `ARCH` column lists the CPU
-architectures each image ships for, resolved by querying the
-repository's multi-arch manifest index; images whose `latest` tag is
-missing or single-architecture show `?`.
+architectures each image ships for, resolved by querying each
+repository's published tag metadata. Only images that can be installed
+are shown: a hit is dropped when its architecture cannot be determined
+or when it ships only architectures proot-distro cannot install, so
+every row (and every name `--quiet` prints) is a valid `install`
+target.
 
 Examples:
 

--- a/proot_distro/__init__.py
+++ b/proot_distro/__init__.py
@@ -22,4 +22,33 @@
 
 Public entry point is :func:`proot_distro.cli.main`, exposed as the
 `proot-distro` and `pd` console scripts via pyproject.toml.
+
+A programmatic interface is also available on this package root:
+
+    import proot_distro
+
+    result = proot_distro.run("ubuntu", ["echo", "hello"])
+    print(result.stdout)
+
+    proot_distro.reinstall("ubuntu")
+
+See :mod:`proot_distro.api` for the full reference.
 """
+
+from proot_distro.api import (
+    ProotDistroError,
+    ContainerNotInstalled,
+    CommandError,
+    ProotResult,
+    run,
+    reinstall,
+)
+
+__all__ = (
+    "ProotDistroError",
+    "ContainerNotInstalled",
+    "CommandError",
+    "ProotResult",
+    "run",
+    "reinstall",
+)

--- a/proot_distro/api.py
+++ b/proot_distro/api.py
@@ -1,0 +1,257 @@
+#
+# Proot-Distro - manage proot containers.
+#
+# Created by Sylirre <sylirre@termux.dev> for Termux project.
+# Development assisted by Claude Code (https://claude.ai/code).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Architecture: Programmatic interface for driving proot-distro from
+# Python without shelling out to the CLI. The public entry points are
+# re-exported on the package root (proot_distro/__init__.py):
+#
+#   proot_distro.run(...)       — run a command inside a container,
+#                                 capturing stdout/stderr and the exit code.
+#   proot_distro.reinstall(...) — wipe a container's rootfs and rebuild it
+#                                 from the image reference stored in its
+#                                 manifest.json.
+#
+# Both reuse the same internals as the CLI — build_login_runtime for the
+# proot argv + guest environment, command_install for the reinstall
+# pipeline — so the two frontends can never drift. The only external
+# binary ever spawned is proot itself, the same one the CLI exec's.
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from proot_distro.message import log_info
+from proot_distro.locking import ContainerLock
+from proot_distro.names import require_valid_name
+from proot_distro.paths import container_manifest, container_rootfs
+from proot_distro.commands.install import command_install
+from proot_distro.commands.login import build_login_runtime
+from proot_distro.commands.remove import _remove_path
+
+
+class ProotDistroError(Exception):
+    """Base exception for the proot-distro Python interface."""
+
+
+class ContainerNotInstalled(ProotDistroError):
+    """Raised when an operation targets a container that is not installed."""
+
+
+class CommandError(ProotDistroError):
+    """Raised by run(check=True) when the guest command exits non-zero."""
+
+
+class ProotResult:
+    """Outcome of running a command inside a container.
+
+    Attributes:
+        returncode: exit status of the guest command (int).
+        stdout:     captured standard output (bytes).
+        stderr:     captured standard error (bytes).
+    """
+
+    __slots__ = ("returncode", "stdout", "stderr")
+
+    def __init__(self, returncode: int, stdout: bytes, stderr: bytes) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    @property
+    def ok(self) -> bool:
+        """True iff the guest command exited with status 0."""
+        return self.returncode == 0
+
+    def __repr__(self) -> str:
+        return (
+            f"ProotResult(returncode={self.returncode}, "
+            f"stdout={self.stdout!r}, stderr={self.stderr!r})"
+        )
+
+
+def run(
+    distribution: str,
+    argv,
+    *,
+    user: str = "root",
+    work_dir: str = "",
+    env: "list | None" = None,
+    bind: "list | None" = None,
+    isolated: bool = False,
+    minimal: bool = False,
+    check: bool = False,
+) -> ProotResult:
+    """Run a command inside *distribution* and capture its output.
+
+    ``argv`` must be a non-empty sequence of strings — the guest command
+    and its arguments. A plain string is rejected to avoid surprising
+    shell behaviour; pass ``["echo", "hello"]``, not ``"echo hello"``.
+
+    Keyword options mirror the CLI's ``run`` flags:
+
+      user      — user name, numeric UID, or 'user:group' (default root)
+      work_dir  — working directory inside the guest (default: the
+                  image's WorkingDir, else the user's home / '/')
+      env       — extra VAR=VALUE strings added to the guest environment
+      bind      — extra --bind entries (source[:destination])
+      isolated  /  minimal  — run a stripped-down session
+      check     — raise CommandError when the command exits non-zero
+
+    Returns a :class:`ProotResult`. Raises :class:`ContainerNotInstalled`
+    when the container does not exist, :class:`TypeError` when ``argv`` is
+    a string, and :class:`ValueError` when ``argv`` is empty. Fatal CLI
+    errors (unknown user, missing shell, unavailable emulator, ...)
+    propagate as ``SystemExit``, matching the CLI's behaviour.
+    """
+    if isinstance(argv, str):
+        raise TypeError(
+            "argv must be a sequence of arguments, not a string. "
+            "Pass e.g. ['echo', 'hello']."
+        )
+    argv = [str(a) for a in argv]
+    if not argv:
+        raise ValueError("argv must not be empty.")
+
+    require_valid_name(distribution)
+
+    if not os.path.isdir(container_rootfs(distribution)):
+        raise ContainerNotInstalled(
+            f"container '{distribution}' is not installed."
+        )
+
+    args = SimpleNamespace(
+        container_name=distribution,
+        user=user or "root",
+        kernel=None,
+        hostname=None,
+        work_dir=work_dir or "",
+        redirect_ports=False,
+        isolated=isolated,
+        minimal=minimal,
+        shared_home=False,
+        shared_tmp=False,
+        shared_x11=False,
+        no_link2symlink=False,
+        no_sysvipc=False,
+        no_kill_on_exit=False,
+        bind=list(bind or []),
+        env=list(env or []),
+        login_cmd=[],
+        _run_inner=argv,
+        emulator=None,
+    )
+
+    # A shared container lock is held for the duration of the run so
+    # install/remove/reset cannot race the guest. Unlike the CLI there is
+    # no exec: subprocess.run blocks, the parent keeps the fd, and the
+    # lock is released when this context exits.
+    with ContainerLock(distribution, exclusive=False, command="run"):
+        rt = build_login_runtime(distribution, args)
+        try:
+            proc = subprocess.run(
+                rt["proot_args"],
+                env=rt["child_env"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        except FileNotFoundError:
+            raise ProotDistroError(
+                f"proot executable '{rt['proot_bin']}' was not found; "
+                "install it or point PD_PROOT_BIN at a working proot."
+            ) from None
+
+    result = ProotResult(proc.returncode, proc.stdout, proc.stderr)
+    if check and not result.ok:
+        detail = proc.stderr.decode(errors="replace").rstrip()
+        raise CommandError(
+            f"command {argv!r} exited with status {proc.returncode}"
+            + (f": {detail}" if detail else "")
+        )
+    return result
+
+
+def reinstall(distribution: str, *, allow_insecure: bool = False) -> None:
+    """Wipe the rootfs of *distribution* and rebuild it from its manifest.
+
+    The container's image reference and architecture are read from
+    ``containers/<name>/manifest.json`` (written by the original
+    install), so the reinstall keeps the same image and container name.
+    The manifest itself is preserved. Returns None on success.
+
+    Raises :class:`ContainerNotInstalled` when the container does not
+    exist and :class:`ProotDistroError` when its manifest cannot be used
+    for a reinstall. Fatal install errors (network failure, invalid
+    image, ...) propagate as ``SystemExit``, matching the CLI's ``reset``.
+    """
+    require_valid_name(distribution)
+
+    rootfs_dir = container_rootfs(distribution)
+    if not os.path.isdir(rootfs_dir):
+        raise ContainerNotInstalled(
+            f"container '{distribution}' is not installed."
+        )
+
+    image_ref = None
+    override_arch = None
+    try:
+        with open(container_manifest(distribution)) as fh:
+            manifest_data = json.load(fh)
+        image_ref = manifest_data.get("image_ref")
+        override_arch = manifest_data.get("arch")
+    except FileNotFoundError:
+        pass
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProotDistroError(
+            f"cannot read manifest for '{distribution}': {exc}"
+        ) from exc
+
+    if not image_ref:
+        raise ProotDistroError(
+            f"container '{distribution}' has no OCI manifest. "
+            "Reinstall is supported for OCI images only."
+        )
+
+    with ContainerLock(distribution, exclusive=True, command="reinstall"):
+        log_info(f"Removing rootfs of '{distribution}'...")
+        if not _remove_path(rootfs_dir):
+            shutil.rmtree(rootfs_dir, ignore_errors=True)
+
+        command_install(
+            SimpleNamespace(
+                image_ref=image_ref,
+                custom_container_name=distribution,
+                override_arch=override_arch,
+                allow_insecure=allow_insecure,
+            )
+        )
+
+
+__all__ = (
+    "ProotDistroError",
+    "ContainerNotInstalled",
+    "CommandError",
+    "ProotResult",
+    "run",
+    "reinstall",
+)

--- a/proot_distro/cli.py
+++ b/proot_distro/cli.py
@@ -56,6 +56,7 @@ from proot_distro.commands.sync import command_sync
 from proot_distro.commands.run import command_run
 from proot_distro.commands.build import command_build
 from proot_distro.commands.push import command_push
+from proot_distro.commands.search import command_search
 from proot_distro.commands.ps import command_ps
 from proot_distro.commands.kill import command_kill
 
@@ -75,6 +76,7 @@ _COMMAND_HANDLERS = {
     "run":         command_run,
     "build":       command_build,
     "push":        command_push,
+    "search":      command_search,
     "ps":          command_ps,
     "kill":        command_kill,
     "help":        command_help,
@@ -176,13 +178,14 @@ def _ensure_proot_available(first_canonical: str) -> None:
     `build` and `push` are exempt from this startup probe: `build` may
     run a Dockerfile with no RUN instructions in pure-Python mode, and
     `push` only reads from the local manifest/layer cache and uploads
-    to a registry. `build` runs its own check after parsing the
-    Dockerfile and refuses only when RUN (or ONBUILD RUN) is actually
-    present. `kill` and `ps` are exempt too: they only inspect and
-    signal already-running sessions via the session registry and never
-    invoke proot.
+    to a registry. `search` only queries the Docker Hub search API and
+    downloads nothing, so it is exempt too. `build` runs its own check
+    after parsing the Dockerfile and refuses only when RUN (or ONBUILD
+    RUN) is actually present. `kill` and `ps` are exempt too: they only
+    inspect and signal already-running sessions via the session registry
+    and never invoke proot.
     """
-    if first_canonical in ("build", "push", "kill", "ps"):
+    if first_canonical in ("build", "push", "kill", "ps", "search"):
         return
     ensure_proot_installed()
 
@@ -322,10 +325,10 @@ def main() -> None:
 
     # Enable quiet mode globally before dispatch so helpers
     # (helpers/docker, helpers/download, etc.) silence their info
-    # lines and progress bars too. `list` and `ps` have different
-    # --quiet semantics (print names / PIDs only) and do not use
-    # log_info(), so the global flag is left off for them.
-    if canonical not in ("list", "ps") and getattr(args, "quiet", False):
+    # lines and progress bars too. `list`, `ps`, and `search` have
+    # different --quiet semantics (print names / PIDs only) and do not
+    # use log_info(), so the global flag is left off for them.
+    if canonical not in ("list", "ps", "search") and getattr(args, "quiet", False):
         set_quiet(True)
 
     handler = _COMMAND_HANDLERS.get(canonical)

--- a/proot_distro/commands/help/pages.py
+++ b/proot_distro/commands/help/pages.py
@@ -756,7 +756,8 @@ HELP_PAGES = {
         "options": [
             ("-h, --help", "Show this help."),
             ("--limit [N]",
-             "Maximum number of results to show (default: 25)."),
+             "Maximum number of results to show (default: 100). Limits "
+             "over 100 fetch further pages from Docker Hub."),
             ("-q, --quiet",
              "Print only the repository names, one per line. Mutually "
              "exclusive with the table output."),

--- a/proot_distro/commands/help/pages.py
+++ b/proot_distro/commands/help/pages.py
@@ -750,6 +750,10 @@ HELP_PAGES = {
             "official or automated, and the CPU architectures each "
             "image ships for."
             "\n\n"
+            "Only images that can be installed are shown — a hit is "
+            "dropped when its architecture cannot be determined or when "
+            "it ships only architectures proot-distro cannot install."
+            "\n\n"
             "Install a hit directly with "
             f"'{PROGRAM_NAME} install <image>'. Search is read-only "
             "and requires no authentication."
@@ -757,8 +761,9 @@ HELP_PAGES = {
         "options": [
             ("-h, --help", "Show this help."),
             ("--limit [N]",
-             "Maximum number of results to show (default: 100). Limits "
-             "over 100 fetch further pages from Docker Hub."),
+             "Maximum number of results to fetch from Docker Hub. The "
+             "default is unlimited — every repository the API will "
+             "serve for the query."),
             ("-q, --quiet",
              "Print only the repository names, one per line. Mutually "
              "exclusive with the table output."),
@@ -778,9 +783,12 @@ HELP_PAGES = {
                     "so custom registries cannot be searched."
                     "\n\n"
                     "The ARCH column is resolved by querying each "
-                    "repository's multi-arch manifest index. Images "
-                    "whose 'latest' tag is missing or single-architecture "
-                    "show '?'."
+                    "repository's published tag metadata, which names "
+                    "the CPU architecture of every platform the image "
+                    "ships. Images whose architecture cannot be "
+                    "determined, or that ship no architecture "
+                    "proot-distro can install, are dropped from the "
+                    "results."
                 ),
             },
         ],

--- a/proot_distro/commands/help/pages.py
+++ b/proot_distro/commands/help/pages.py
@@ -510,7 +510,8 @@ HELP_PAGES = {
              "supported. FILE must be executable."),
             ("--kernel [TEXT]",
              "Customize the kernel release string reported by uname."),
-            ("--hostname [TEXT]", "Customize the system hostname."),
+            ("--hostname [TEXT]",
+             "Customize the system hostname (default: container name)."),
             ("-w, --work-dir [PATH]", "Set the initial working directory."),
             ("-e, --env VAR=VALUE",
              "Set an environment variable. Can be specified multiple "
@@ -733,6 +734,50 @@ HELP_PAGES = {
         ],
     },
 
+    "search": {
+        "usage": "search [OPTIONS] TERM",
+        "summary": (
+            "Search Docker Hub for repositories matching TERM, like "
+            "'docker search'. Results show the repository name, a short "
+            "description, the star count, whether the repository is "
+            "official or automated, and the CPU architectures each "
+            "image ships for."
+            "\n\n"
+            "Install a hit directly with "
+            f"'{PROGRAM_NAME} install <image>'. Search is read-only "
+            "and requires no authentication."
+        ),
+        "options": [
+            ("-h, --help", "Show this help."),
+            ("--limit [N]",
+             "Maximum number of results to show (default: 25)."),
+            ("-q, --quiet",
+             "Print only the repository names, one per line. Mutually "
+             "exclusive with the table output."),
+        ],
+        "examples": [
+            f"{PROGRAM_NAME} search ubuntu",
+            f"{PROGRAM_NAME} search --limit 10 alpine",
+            f"{PROGRAM_NAME} search -q nextcloud",
+        ],
+        "footer": [
+            {
+                "title": "NOTES",
+                "intro": (
+                    "Search is only available for Docker Hub — the "
+                    "default registry. The OCI Distribution "
+                    "specification defines no standard search endpoint, "
+                    "so custom registries cannot be searched."
+                    "\n\n"
+                    "The ARCH column is resolved by querying each "
+                    "repository's multi-arch manifest index. Images "
+                    "whose 'latest' tag is missing or single-architecture "
+                    "show '?'."
+                ),
+            },
+        ],
+    },
+
     "run": {
         "usage": "run [OPTIONS] CONTAINER [-- ARG ...]",
         "summary": (
@@ -800,7 +845,8 @@ HELP_PAGES = {
              "supported. FILE must be executable."),
             ("--kernel [TEXT]",
              "Customize the kernel release string reported by uname."),
-            ("--hostname [TEXT]", "Customize the system hostname."),
+            ("--hostname [TEXT]",
+             "Customize the system hostname (default: container name)."),
             ("-w, --work-dir [PATH]", "Set the initial working directory."),
             ("-e, --env VAR=VALUE",
              "Set an environment variable. Can be specified multiple "
@@ -896,4 +942,5 @@ TOP_COMMANDS = [
     ("sync", "Sync files from/to container."),
     ("build", "Build an OCI image from a Dockerfile."),
     ("push", "Push a locally built image to a registry."),
+    ("search", "Search Docker Hub for images."),
 ]

--- a/proot_distro/commands/login/__init__.py
+++ b/proot_distro/commands/login/__init__.py
@@ -307,7 +307,21 @@ def _check_shell_available(rootfs, container_path, login_shell, container_name):
     sys.exit(1)
 
 
-def _command_login_inner(container_name: str, args, lock) -> None:
+def build_login_runtime(container_name: str, args) -> dict:
+    """Resolve the runtime state of a login/run session without exec'ing.
+
+    Shared by the CLI (command_login, which then registers the session
+    and exec's proot) and the programmatic API (proot_distro.api.run,
+    which runs the resulting argv via subprocess), so the two frontends
+    can never drift on proot argv, guest environment, or user/bind/env
+    resolution.
+
+    Returns a dict with the resolved rootfs, distro type, child
+    environment, proot argv and session metadata. Unresolvable state
+    (missing rootfs, unknown user, unavailable shell, unemulatable
+    Termux-type container) is fatal and exits with the CLI's usual
+    messages.
+    """
     migrate_legacy_rootfs(container_name)
 
     rootfs = container_rootfs(container_name)
@@ -323,7 +337,7 @@ def _command_login_inner(container_name: str, args, lock) -> None:
         getattr(args, "kernel", DEFAULT_FAKE_KERNEL_RELEASE)
         or DEFAULT_FAKE_KERNEL_RELEASE
     )
-    hostname = getattr(args, "hostname", "localhost") or "localhost"
+    hostname = getattr(args, "hostname", "") or container_name
     login_wd = getattr(args, "work_dir", "") or ""
     redirect_ports = getattr(args, "redirect_ports", False)
     isolated = getattr(args, "isolated", False)
@@ -338,7 +352,6 @@ def _command_login_inner(container_name: str, args, lock) -> None:
     extra_env = getattr(args, "env", []) or []
     login_cmd = getattr(args, "login_cmd", []) or []
     run_inner = getattr(args, "_run_inner", None)
-    detach = getattr(args, "detach", False)
 
     if dist_type == "termux":
         if not login_wd:
@@ -468,6 +481,39 @@ def _command_login_inner(container_name: str, args, lock) -> None:
         child_env["PROOT_L2S_DIR"] = l2s_dir
     child_env.pop("LD_PRELOAD", None)
 
+    return {
+        "container_name": container_name,
+        "rootfs": rootfs,
+        "dist_type": dist_type,
+        "container_path": container_path,
+        "child_env": child_env,
+        "proot_bin": proot_bin,
+        "proot_args": proot_args,
+        "login_user": login_user,
+        "login_uid": login_uid,
+        "login_gid": login_gid,
+        "login_home": login_home,
+        "inner": inner,
+        "isolated": isolated,
+        "minimal": minimal,
+        "hostname": hostname,
+        "kernel_release": kernel_release,
+    }
+
+
+def _command_login_inner(container_name: str, args, lock) -> None:
+    rt = build_login_runtime(container_name, args)
+
+    child_env = rt["child_env"]
+    proot_bin = rt["proot_bin"]
+    proot_args = rt["proot_args"]
+    inner = rt["inner"]
+    login_user = rt["login_user"]
+    isolated = rt["isolated"]
+    minimal = rt["minimal"]
+    run_inner = getattr(args, "_run_inner", None)
+    detach = getattr(args, "detach", False)
+
     if getattr(args, "get_proot_cmd", False):
         parts = ["env", "-i"]
         for k, v in child_env.items():
@@ -524,4 +570,4 @@ def _command_login_inner(container_name: str, args, lock) -> None:
     os.execvpe(proot_bin, proot_args, child_env)
 
 
-__all__ = ("command_login",)
+__all__ = ("command_login", "build_login_runtime")

--- a/proot_distro/commands/search.py
+++ b/proot_distro/commands/search.py
@@ -22,10 +22,15 @@
 # search`. Queries Docker Hub through helpers/docker/search.py and
 # renders a NAME/DESCRIPTION/STARS/OFFICIAL/AUTOMATED/ARCH table that
 # degrades to a stacked form on narrow terminals, mirroring the
-# `list --image` layout. The ARCH column is filled by querying each
-# repository's multi-arch manifest index concurrently; images whose
-# 'latest' tag cannot be resolved show '?'. `--quiet` prints bare
-# repository names for piping into `install`.
+# `list --image` layout. `--limit` is a ceiling on the number of
+# results fetched; the default is unlimited, so a search returns every
+# repository Docker Hub will serve for the query. The ARCH column is
+# filled by querying each repository's published tag metadata
+# concurrently; a hit whose architecture cannot be determined — or that
+# ships only architectures proot-distro cannot install — is dropped from
+# the results, so every image shown (and every name `--quiet` prints)
+# can be installed. `--quiet` prints bare repository names for piping
+# into `install`.
 
 import sys
 import urllib.error
@@ -35,7 +40,9 @@ from proot_distro.constants import PROGRAM_NAME
 from proot_distro.message import (
     C, msg, log_info, log_error, crit_error, terminal_width,
 )
-from proot_distro.helpers.docker import image_architectures, search_images
+from proot_distro.helpers.docker import (
+    image_architectures, is_installable, search_images,
+)
 
 # Fixed column order of the results table (docker search columns plus ARCH).
 _HEADERS = ("NAME", "DESCRIPTION", "STARS", "OFFICIAL", "AUTOMATED", "ARCH")
@@ -43,8 +50,10 @@ _GAP = 2
 # DESCRIPTION column must keep at least this many columns before the
 # table degrades to the stacked form (Termux on a phone).
 _STACKED_MIN = 24
-# Concurrent manifest-index queries per search (capped at the result count).
-_ARCH_WORKERS = 8
+# Concurrent manifest queries per search (capped at the result count).
+# High enough that a full search stays interactive, low enough not to
+# hammer the registry.
+_ARCH_WORKERS = 16
 
 
 def command_search(args) -> None:
@@ -53,7 +62,7 @@ def command_search(args) -> None:
     if not query:
         crit_error("search term is not specified.")
         sys.exit(1)
-    limit = getattr(args, "limit", 100) or 100
+    limit = getattr(args, "limit", None)
     quiet = bool(getattr(args, "quiet", False))
 
     try:
@@ -77,23 +86,34 @@ def command_search(args) -> None:
         log_error(f"Error: {exc}")
         sys.exit(1)
 
+    # Every result must resolve to a real, installable architecture —
+    # for `--quiet`, too, since the names are meant to be piped into
+    # `install`. Unknown-arch hits and hits shipping only architectures
+    # proot-distro cannot install are dropped here.
+    if results:
+        _resolve_architectures(results)
+        before = len(results)
+        results = [r for r in results
+                   if is_installable(r.get("architectures") or [])]
+        dropped = before - len(results)
+        if dropped:
+            log_info(f"Dropped {dropped} image(s) with no installable "
+                     f"architecture.")
+
     if quiet:
         for result in results:
             print(result.get("name", "?"))
         return
 
-    if results:
-        log_info(f"Resolving architectures for {len(results)} image(s)...")
-        _resolve_architectures(results)
-
     msg()
     if not results:
-        msg(f"{C['YELLOW']}No results found for '{query}' on Docker Hub."
-            f"{C['RST']}")
+        msg(f"{C['YELLOW']}No installable images found for '{query}' on "
+            f"Docker Hub.{C['RST']}")
         msg()
         return
 
-    msg(f"{C['CYAN']}Search results for '{query}' on Docker Hub:{C['RST']}")
+    msg(f"{C['CYAN']}Search results for '{query}' on Docker Hub:"
+        f"{C['RST']}")
     msg()
     _render_results(results)
     msg()
@@ -107,13 +127,14 @@ def command_search(args) -> None:
 # ---------------------------------------------------------------------------
 
 def _resolve_architectures(results: list) -> None:
-    """Populate each result's 'architectures' from the registry manifest.
+    """Populate each result's 'architectures' from the published tag
+    metadata.
 
-    Every repository is queried for its multi-arch manifest index. The
-    queries run concurrently so a full page of results does not serialize
-    into dozens of sequential round-trips. A repository that cannot be
-    resolved gets an empty list — the table shows '?' for it instead of
-    failing the whole search.
+    Every repository is queried for its published tag metadata. The
+    queries run concurrently so a full page of results does not
+    serialize into dozens of sequential round-trips. A repository that
+    cannot be resolved gets an empty list — command_search drops such a
+    hit rather than showing it, since it cannot be installed.
     """
     names = [result.get("name") or "?" for result in results]
     workers = min(_ARCH_WORKERS, len(names))

--- a/proot_distro/commands/search.py
+++ b/proot_distro/commands/search.py
@@ -53,7 +53,7 @@ def command_search(args) -> None:
     if not query:
         crit_error("search term is not specified.")
         sys.exit(1)
-    limit = getattr(args, "limit", 25) or 25
+    limit = getattr(args, "limit", 100) or 100
     quiet = bool(getattr(args, "quiet", False))
 
     try:

--- a/proot_distro/commands/search.py
+++ b/proot_distro/commands/search.py
@@ -1,0 +1,199 @@
+#
+# Proot-Distro - manage proot containers.
+#
+# Created by Sylirre <sylirre@termux.dev> for Termux project.
+# Development assisted by Claude Code (https://claude.ai/code).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Architecture: `proot-distro search TERM`, the analogue of `docker
+# search`. Queries Docker Hub through helpers/docker/search.py and
+# renders a NAME/DESCRIPTION/STARS/OFFICIAL/AUTOMATED/ARCH table that
+# degrades to a stacked form on narrow terminals, mirroring the
+# `list --image` layout. The ARCH column is filled by querying each
+# repository's multi-arch manifest index concurrently; images whose
+# 'latest' tag cannot be resolved show '?'. `--quiet` prints bare
+# repository names for piping into `install`.
+
+import sys
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor
+
+from proot_distro.constants import PROGRAM_NAME
+from proot_distro.message import (
+    C, msg, log_info, log_error, crit_error, terminal_width,
+)
+from proot_distro.helpers.docker import image_architectures, search_images
+
+# Fixed column order of the results table (docker search columns plus ARCH).
+_HEADERS = ("NAME", "DESCRIPTION", "STARS", "OFFICIAL", "AUTOMATED", "ARCH")
+_GAP = 2
+# DESCRIPTION column must keep at least this many columns before the
+# table degrades to the stacked form (Termux on a phone).
+_STACKED_MIN = 24
+# Concurrent manifest-index queries per search (capped at the result count).
+_ARCH_WORKERS = 8
+
+
+def command_search(args) -> None:
+    """Implements `proot-distro search`."""
+    query = getattr(args, "query", None) or ""
+    if not query:
+        crit_error("search term is not specified.")
+        sys.exit(1)
+    limit = getattr(args, "limit", 25) or 25
+    quiet = bool(getattr(args, "quiet", False))
+
+    try:
+        results = search_images(query, limit)
+    except KeyboardInterrupt:
+        if sys.stderr.isatty():
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+        log_error("Aborted by user.")
+        sys.exit(1)
+    except (urllib.error.URLError, OSError) as exc:
+        if sys.stderr.isatty():
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+        log_error(f"Network error: {exc}")
+        sys.exit(1)
+    except RuntimeError as exc:
+        if sys.stderr.isatty():
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+        log_error(f"Error: {exc}")
+        sys.exit(1)
+
+    if quiet:
+        for result in results:
+            print(result.get("name", "?"))
+        return
+
+    if results:
+        log_info(f"Resolving architectures for {len(results)} image(s)...")
+        _resolve_architectures(results)
+
+    msg()
+    if not results:
+        msg(f"{C['YELLOW']}No results found for '{query}' on Docker Hub."
+            f"{C['RST']}")
+        msg()
+        return
+
+    msg(f"{C['CYAN']}Search results for '{query}' on Docker Hub:{C['RST']}")
+    msg()
+    _render_results(results)
+    msg()
+    msg(f"{C['CYAN']}Install with: "
+        f"{C['GREEN']}{PROGRAM_NAME} install <image>{C['RST']}")
+    msg()
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def _resolve_architectures(results: list) -> None:
+    """Populate each result's 'architectures' from the registry manifest.
+
+    Every repository is queried for its multi-arch manifest index. The
+    queries run concurrently so a full page of results does not serialize
+    into dozens of sequential round-trips. A repository that cannot be
+    resolved gets an empty list — the table shows '?' for it instead of
+    failing the whole search.
+    """
+    names = [result.get("name") or "?" for result in results]
+    workers = min(_ARCH_WORKERS, len(names))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        archs = list(pool.map(image_architectures, names))
+    for result, arch in zip(results, archs):
+        result["architectures"] = arch
+
+
+def _row(result: dict) -> tuple:
+    """Turn one API result into the (name, desc, stars, official, automated,
+    arch) row tuple shared by both table and stacked renderers."""
+    name = result.get("name", "?")
+    desc = (result.get("description") or "").replace("\n", " ").strip()
+    stars = result.get("star_count") or 0
+    official = "[OK]" if result.get("is_official") else ""
+    automated = "[OK]" if result.get("is_automated") else ""
+    arch = "/".join(result.get("architectures") or []) or "?"
+    return name, desc, str(stars), official, automated, arch
+
+
+def _render_results(results: list) -> None:
+    rows = [_row(r) for r in results]
+    widths = [
+        max(len(_HEADERS[i]), max(len(r[i]) for r in rows))
+        for i in range(len(_HEADERS))
+    ]
+    # NAME/STARS/OFFICIAL/AUTOMATED/ARCH are fixed columns; DESCRIPTION
+    # flexes to consume whatever width the terminal leaves over.
+    fixed = (
+        widths[0] + widths[2] + widths[3] + widths[4] + widths[5]
+        + _GAP * (len(widths) - 1)
+    )
+    desc_limit = terminal_width() - fixed
+    if desc_limit < _STACKED_MIN:
+        _render_stacked(rows)
+        return
+    widths[1] = min(widths[1], desc_limit)
+
+    pad = " " * _GAP
+    head = [_HEADERS[i].ljust(widths[i]) for i in range(len(widths) - 1)]
+    head.append(_HEADERS[-1])
+    msg(f"{C['UBCYAN']}{pad.join(head)}{C['RST']}")
+
+    for row in rows:
+        cells = [
+            f"{C['GREEN']}{_ellipsize(row[0], widths[0]).ljust(widths[0])}"
+            f"{C['RST']}",
+            f"{C['CYAN']}{_ellipsize(row[1], widths[1]).ljust(widths[1])}"
+            f"{C['RST']}",
+            f"{C['CYAN']}{row[2].rjust(widths[2])}{C['RST']}",
+            f"{C['CYAN']}{row[3].ljust(widths[3])}{C['RST']}",
+            f"{C['CYAN']}{row[4].ljust(widths[4])}{C['RST']}",
+            f"{C['CYAN']}{row[5]}{C['RST']}",
+        ]
+        msg(pad.join(cells))
+
+
+def _render_stacked(rows: list) -> None:
+    """Print one result per two lines — for terminals too narrow to align."""
+    for i, row in enumerate(rows):
+        if i:
+            msg()
+        msg(f"  {C['CYAN']}* {C['GREEN']}{row[0]}{C['RST']}")
+        detail = [row[1]]
+        flags = " ".join(f for f in (row[3], row[4]) if f)
+        if flags:
+            detail.append(flags)
+        detail.append(f"{row[2]} stars")
+        detail.append(f"arch: {row[5]}")
+        msg(f"    {C['CYAN']}{', '.join(d for d in detail if d)}{C['RST']}")
+
+
+def _ellipsize(text: str, width: int) -> str:
+    """Truncate *text* to *width* columns, appending an ellipsis when cut."""
+    if len(text) <= width:
+        return text
+    if width <= 1:
+        return text[:width]
+    return text[: width - 1] + "…"
+
+
+__all__ = ("command_search",)

--- a/proot_distro/completions/_proot-distro
+++ b/proot_distro/completions/_proot-distro
@@ -85,6 +85,7 @@ _proot_distro() {
                 'run:run the image entrypoint/cmd in a container'
                 'build:build an OCI image from a Dockerfile'
                 'push:push a locally built image to a registry'
+                'search:search Docker Hub for images'
                 'help:show help'
             )
             _describe 'command' subcommands
@@ -311,12 +312,21 @@ _proot_distro() {
                     ;;
 
                 # -----------------------------------------------------------
+                search)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[show help]' \
+                        '--limit[maximum number of results]:N' \
+                        '(-q --quiet)'{-q,--quiet}'[print only repository names, one per line]' \
+                        '1:search term'
+                    ;;
+
+                # -----------------------------------------------------------
                 help)
                     local -a topics
                     topics=(
                         install remove rename reset login list ps kill
                         backup restore clear-cache copy sync run
-                        build push
+                        build push search
                     )
                     _describe 'topic' topics
                     ;;

--- a/proot_distro/completions/proot-distro.bash
+++ b/proot_distro/completions/proot-distro.bash
@@ -55,7 +55,7 @@ _proot_distro() {
     _init_completion || return
 
     local -r _all_commands="install remove rename reset login list ps kill backup restore
-        clear-cache copy sync run build push help"
+        clear-cache copy sync run build push search help"
 
     # Complete the subcommand itself
     if [[ ${cword} -eq 1 ]]; then
@@ -320,8 +320,18 @@ _proot_distro() {
             ;;
 
         # -----------------------------------------------------------------------
+        search)
+            case "${prev}" in
+                --limit) return ;;
+            esac
+            if [[ "${cur}" == -* ]]; then
+                COMPREPLY=($(compgen -W "--limit -q --quiet -h --help" -- "${cur}"))
+            fi
+            ;;
+
+        # -----------------------------------------------------------------------
         help)
-            local topics="install remove rename reset login list ps kill backup restore clear-cache copy sync run build push"
+            local topics="install remove rename reset login list ps kill backup restore clear-cache copy sync run build push search"
             COMPREPLY=($(compgen -W "${topics}" -- "${cur}"))
             ;;
 

--- a/proot_distro/completions/proot-distro.fish
+++ b/proot_distro/completions/proot-distro.fish
@@ -71,7 +71,7 @@ end
 function __proot_distro_no_subcommand
     not __fish_seen_subcommand_from \
         install remove rename reset login list ps kill backup restore \
-        clear-cache copy sync run build push help
+        clear-cache copy sync run build push search help
 end
 
 # ---------------------------------------------------------------------------
@@ -93,6 +93,7 @@ complete -c proot-distro -f -n __proot_distro_no_subcommand -a sync        -d 'S
 complete -c proot-distro -f -n __proot_distro_no_subcommand -a run         -d 'Run the image entrypoint/cmd in a container'
 complete -c proot-distro -f -n __proot_distro_no_subcommand -a build       -d 'Build an OCI image from a Dockerfile'
 complete -c proot-distro -f -n __proot_distro_no_subcommand -a push        -d 'Push a locally built image to a registry'
+complete -c proot-distro -f -n __proot_distro_no_subcommand -a search      -d 'Search Docker Hub for images'
 complete -c proot-distro -f -n __proot_distro_no_subcommand -a help        -d 'Show help'
 
 # Global help flag (before subcommand)
@@ -386,10 +387,20 @@ complete -c proot-distro -f -n '__fish_seen_subcommand_from push' \
     -s h -l help       -d 'Show help'
 
 # ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
+    -l limit          -r -d 'Maximum number of results (default: 25)'
+complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
+    -s q -l quiet     -d 'Print only repository names, one per line'
+complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
+    -s h -l help      -d 'Show help'
+
+# ---------------------------------------------------------------------------
 # help
 # ---------------------------------------------------------------------------
 complete -c proot-distro -f -n '__fish_seen_subcommand_from help' \
-    -a 'install remove rename reset login list ps kill backup restore clear-cache copy sync run build push' \
+    -a 'install remove rename reset login list ps kill backup restore clear-cache copy sync run build push search' \
     -d 'Topic'
 
 # ---------------------------------------------------------------------------
@@ -411,6 +422,7 @@ complete -c pd -f -n __proot_distro_no_subcommand -a sync        -d 'Synchronize
 complete -c pd -f -n __proot_distro_no_subcommand -a run         -d 'Run the image entrypoint/cmd in a container'
 complete -c pd -f -n __proot_distro_no_subcommand -a build       -d 'Build an OCI image from a Dockerfile'
 complete -c pd -f -n __proot_distro_no_subcommand -a push        -d 'Push a locally built image to a registry'
+complete -c pd -f -n __proot_distro_no_subcommand -a search      -d 'Search Docker Hub for images'
 complete -c pd -f -n __proot_distro_no_subcommand -a help        -d 'Show help'
 complete -c pd -f -n __proot_distro_no_subcommand -s h -l help   -d 'Show help'
 
@@ -536,5 +548,9 @@ complete -c pd -f -n '__fish_seen_subcommand_from push' -l allow-insecure       
 complete -c pd -f -n '__fish_seen_subcommand_from push' -s q -l quiet           -d 'Suppress non-error output'
 complete -c pd -f -n '__fish_seen_subcommand_from push' -s h -l help            -d 'Show help'
 
+complete -c pd -f -n '__fish_seen_subcommand_from search' -l limit       -r -d 'Maximum number of results (default: 25)'
+complete -c pd -f -n '__fish_seen_subcommand_from search' -s q -l quiet   -d 'Print only repository names, one per line'
+complete -c pd -f -n '__fish_seen_subcommand_from search' -s h -l help    -d 'Show help'
+
 complete -c pd -f -n '__fish_seen_subcommand_from help' \
-    -a 'install remove rename reset login list ps kill backup restore clear-cache copy sync run build push' -d 'Topic'
+    -a 'install remove rename reset login list ps kill backup restore clear-cache copy sync run build push search' -d 'Topic'

--- a/proot_distro/completions/proot-distro.fish
+++ b/proot_distro/completions/proot-distro.fish
@@ -390,7 +390,7 @@ complete -c proot-distro -f -n '__fish_seen_subcommand_from push' \
 # search
 # ---------------------------------------------------------------------------
 complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
-    -l limit          -r -d 'Maximum number of results (default: 25)'
+    -l limit          -r -d 'Maximum number of results (default: 100)'
 complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
     -s q -l quiet     -d 'Print only repository names, one per line'
 complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
@@ -548,7 +548,7 @@ complete -c pd -f -n '__fish_seen_subcommand_from push' -l allow-insecure       
 complete -c pd -f -n '__fish_seen_subcommand_from push' -s q -l quiet           -d 'Suppress non-error output'
 complete -c pd -f -n '__fish_seen_subcommand_from push' -s h -l help            -d 'Show help'
 
-complete -c pd -f -n '__fish_seen_subcommand_from search' -l limit       -r -d 'Maximum number of results (default: 25)'
+complete -c pd -f -n '__fish_seen_subcommand_from search' -l limit       -r -d 'Maximum number of results (default: 100)'
 complete -c pd -f -n '__fish_seen_subcommand_from search' -s q -l quiet   -d 'Print only repository names, one per line'
 complete -c pd -f -n '__fish_seen_subcommand_from search' -s h -l help    -d 'Show help'
 

--- a/proot_distro/completions/proot-distro.fish
+++ b/proot_distro/completions/proot-distro.fish
@@ -390,7 +390,7 @@ complete -c proot-distro -f -n '__fish_seen_subcommand_from push' \
 # search
 # ---------------------------------------------------------------------------
 complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
-    -l limit          -r -d 'Maximum number of results (default: 100)'
+    -l limit          -r -d 'Maximum number of results (default: unlimited)'
 complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
     -s q -l quiet     -d 'Print only repository names, one per line'
 complete -c proot-distro -f -n '__fish_seen_subcommand_from search' \
@@ -548,7 +548,7 @@ complete -c pd -f -n '__fish_seen_subcommand_from push' -l allow-insecure       
 complete -c pd -f -n '__fish_seen_subcommand_from push' -s q -l quiet           -d 'Suppress non-error output'
 complete -c pd -f -n '__fish_seen_subcommand_from push' -s h -l help            -d 'Show help'
 
-complete -c pd -f -n '__fish_seen_subcommand_from search' -l limit       -r -d 'Maximum number of results (default: 100)'
+complete -c pd -f -n '__fish_seen_subcommand_from search' -l limit       -r -d 'Maximum number of results (default: unlimited)'
 complete -c pd -f -n '__fish_seen_subcommand_from search' -s q -l quiet   -d 'Print only repository names, one per line'
 complete -c pd -f -n '__fish_seen_subcommand_from search' -s h -l help    -d 'Show help'
 

--- a/proot_distro/helpers/docker/__init__.py
+++ b/proot_distro/helpers/docker/__init__.py
@@ -32,6 +32,8 @@
 #                    through manifest fetch, layer download, apply.
 #   push.py        — push_image: blob existence probe, upload session,
 #                    monolithic PUT, manifest PUT.
+#   search.py      — search_images: Docker Hub repository search;
+#                    image_architectures: a repo's manifest-index archs.
 
 from proot_distro.helpers.docker.refs import (
     ARCH_TO_DOCKER,
@@ -69,6 +71,10 @@ from proot_distro.helpers.docker.layers import (
 )
 from proot_distro.helpers.docker.pull import pull_image
 from proot_distro.helpers.docker.push import push_image
+from proot_distro.helpers.docker.search import (
+    image_architectures,
+    search_images,
+)
 
 __all__ = (
     "ARCH_TO_DOCKER",
@@ -85,6 +91,7 @@ __all__ = (
     "download_blob",
     "env_basic_auth",
     "get_auth_token",
+    "image_architectures",
     "image_cache_entry",
     "insecure_registry_msg",
     "iter_cached_images",
@@ -97,6 +104,7 @@ __all__ = (
     "push_image",
     "registry_base_url",
     "save_manifest_cache",
+    "search_images",
     "validate_digest",
     "with_explicit_tag",
 )

--- a/proot_distro/helpers/docker/__init__.py
+++ b/proot_distro/helpers/docker/__init__.py
@@ -73,6 +73,7 @@ from proot_distro.helpers.docker.pull import pull_image
 from proot_distro.helpers.docker.push import push_image
 from proot_distro.helpers.docker.search import (
     image_architectures,
+    is_installable,
     search_images,
 )
 
@@ -94,6 +95,7 @@ __all__ = (
     "image_architectures",
     "image_cache_entry",
     "insecure_registry_msg",
+    "is_installable",
     "iter_cached_images",
     "layer_cache_path",
     "load_manifest_cache",

--- a/proot_distro/helpers/docker/search.py
+++ b/proot_distro/helpers/docker/search.py
@@ -1,0 +1,158 @@
+#
+# Proot-Distro - manage proot containers.
+#
+# Created by Sylirre <sylirre@termux.dev> for Termux project.
+# Development assisted by Claude Code (https://claude.ai/code).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Architecture: Docker Hub repository search, mirroring `docker search`.
+# The OCI Distribution specification has no standard search endpoint, so
+# search lives against Docker Hub's own REST API (hub.docker.com) rather
+# than the registry protocol in pull.py/push.py. Custom registries
+# therefore cannot be searched — Hub is the default registry anyway.
+#
+# image_architectures() is the second half: it reads a repository's
+# multi-arch manifest index from the registry so the search table can
+# list which CPU architectures each hit ships.
+
+import json
+import urllib.parse
+import urllib.request
+
+from proot_distro.helpers.download import retry_http
+from proot_distro.helpers.docker.media import (
+    DOCKER_MANIFEST_LIST_MEDIA,
+    DOCKER_MANIFEST_MEDIA,
+    OCI_INDEX_MEDIA,
+    OCI_MANIFEST_MEDIA,
+)
+from proot_distro.helpers.docker.refs import DOCKER_TO_ARCH, parse_image_ref
+from proot_distro.helpers.docker.transport import _ua, get_auth_token, opener
+
+
+HUB_SEARCH_URL = "https://hub.docker.com/v2/search/repositories/"
+
+# Media types that describe a multi-architecture image index — the only
+# manifest kind whose entries carry a platform we can read an arch from.
+_INDEX_MEDIA_TYPES = frozenset({DOCKER_MANIFEST_LIST_MEDIA, OCI_INDEX_MEDIA})
+
+# The same Accept list as the pull pipeline, so the registry hands us an
+# index whenever the image ships one (single-arch images answer with their
+# plain manifest instead).
+_INDEX_ACCEPT = ", ".join([
+    OCI_INDEX_MEDIA,
+    DOCKER_MANIFEST_LIST_MEDIA,
+    OCI_MANIFEST_MEDIA,
+    DOCKER_MANIFEST_MEDIA,
+])
+
+
+def search_images(query: str, limit: int = 25) -> list:
+    """Search Docker Hub for repositories matching *query*.
+
+    Returns a list of result dicts carrying the fields `docker search`
+    shows — name, description, star_count, is_official, is_automated —
+    plus the raw pull_count. Transient network failures are retried
+    with the same policy as registry pulls. An empty *query* (after
+    stripping) yields an empty list without any network access.
+    """
+    query = (query or "").strip()
+    if not query:
+        return []
+    params = {"query": query, "page_size": max(1, int(limit)), "page": 1}
+    url = f"{HUB_SEARCH_URL}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers=_ua())
+
+    def _attempt():
+        with opener().open(req) as resp:
+            return resp.read()
+
+    data = json.loads(retry_http(_attempt, what="Searching Docker Hub"))
+    results = []
+    for item in data.get("results", []) or []:
+        results.append(
+            {
+                "name": item.get("repo_name") or item.get("name", "?"),
+                "description": (
+                    item.get("short_description")
+                    or item.get("description")
+                    or ""
+                ),
+                "star_count": item.get("star_count") or 0,
+                "is_official": item.get("is_official") or False,
+                "is_automated": item.get("is_automated") or False,
+                "pull_count": item.get("pull_count") or 0,
+            }
+        )
+    return results
+
+
+def image_architectures(image_ref: str, insecure: bool = False) -> list:
+    """Return the proot-distro arch names *image_ref*'s latest tag ships.
+
+    Search results are repositories, not tags, so the registry is always
+    probed for the 'latest' tag. The multi-arch manifest index is fetched
+    and each entry's platform is mapped back to a proot-distro
+    architecture name (unknown Docker arch names pass through unchanged).
+
+    An empty list is returned whenever the answer cannot be determined —
+    the image is single-architecture (a plain manifest carries no
+    platform), the 'latest' tag does not exist, the repository is private,
+    or the network failed — so a search table never fails because one
+    repository refused to answer.
+    """
+    registry, repo, _tag = parse_image_ref(image_ref)
+    try:
+        token, base = get_auth_token(repo, registry, insecure=insecure)
+    except Exception:
+        return []
+
+    headers = {**_ua(), "Accept": _INDEX_ACCEPT}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        f"{base}/v2/{repo}/manifests/latest", headers=headers
+    )
+
+    def _attempt():
+        with opener(insecure).open(req) as resp:
+            return resp.read(), resp.headers.get("Content-Type", "")
+
+    try:
+        body, ct = retry_http(
+            _attempt, what=f"Fetching manifest for {image_ref}"
+        )
+    except Exception:
+        return []
+    try:
+        data = json.loads(body)
+    except ValueError:
+        return []
+
+    ct = ct.split(";")[0].strip() or data.get("mediaType", "")
+    if ct not in _INDEX_MEDIA_TYPES or "manifests" not in data:
+        return []
+
+    archs = set()
+    for entry in data.get("manifests", []) or []:
+        platform = entry.get("platform", {}) or {}
+        if platform.get("os", "linux") != "linux":
+            continue
+        docker_arch = platform.get("architecture")
+        if not docker_arch:
+            continue
+        archs.add(DOCKER_TO_ARCH.get(docker_arch, docker_arch))
+    return sorted(archs)

--- a/proot_distro/helpers/docker/search.py
+++ b/proot_distro/helpers/docker/search.py
@@ -45,6 +45,11 @@ from proot_distro.helpers.docker.transport import _ua, get_auth_token, opener
 
 HUB_SEARCH_URL = "https://hub.docker.com/v2/search/repositories/"
 
+# Docker Hub caps a single search page at this many results; larger
+# limits are fetched by walking `page` until the limit is satisfied or
+# the API stops answering.
+MAX_PAGE_SIZE = 100
+
 # Media types that describe a multi-architecture image index — the only
 # manifest kind whose entries carry a platform we can read an arch from.
 _INDEX_MEDIA_TYPES = frozenset({DOCKER_MANIFEST_LIST_MEDIA, OCI_INDEX_MEDIA})
@@ -60,7 +65,7 @@ _INDEX_ACCEPT = ", ".join([
 ])
 
 
-def search_images(query: str, limit: int = 25) -> list:
+def search_images(query: str, limit: int = 100) -> list:
     """Search Docker Hub for repositories matching *query*.
 
     Returns a list of result dicts carrying the fields `docker search`
@@ -68,22 +73,32 @@ def search_images(query: str, limit: int = 25) -> list:
     plus the raw pull_count. Transient network failures are retried
     with the same policy as registry pulls. An empty *query* (after
     stripping) yields an empty list without any network access.
+
+    Docker Hub answers at most `MAX_PAGE_SIZE` repositories per page, so
+    a *limit* beyond that walks the `page` parameter until the limit is
+    satisfied or the API stops answering.
     """
     query = (query or "").strip()
     if not query:
         return []
-    params = {"query": query, "page_size": max(1, int(limit)), "page": 1}
-    url = f"{HUB_SEARCH_URL}?{urllib.parse.urlencode(params)}"
-    req = urllib.request.Request(url, headers=_ua())
-
-    def _attempt():
-        with opener().open(req) as resp:
-            return resp.read()
-
-    data = json.loads(retry_http(_attempt, what="Searching Docker Hub"))
+    limit = max(1, int(limit))
     results = []
-    for item in data.get("results", []) or []:
-        results.append(
+    page = 1
+    while len(results) < limit:
+        page_size = min(MAX_PAGE_SIZE, limit - len(results))
+        params = {"query": query, "page_size": page_size, "page": page}
+        url = f"{HUB_SEARCH_URL}?{urllib.parse.urlencode(params)}"
+        req = urllib.request.Request(url, headers=_ua())
+
+        def _attempt():
+            with opener().open(req) as resp:
+                return resp.read()
+
+        data = json.loads(retry_http(_attempt, what="Searching Docker Hub"))
+        fetched = data.get("results", []) or []
+        if not fetched:
+            break
+        results.extend(
             {
                 "name": item.get("repo_name") or item.get("name", "?"),
                 "description": (
@@ -96,7 +111,11 @@ def search_images(query: str, limit: int = 25) -> list:
                 "is_automated": item.get("is_automated") or False,
                 "pull_count": item.get("pull_count") or 0,
             }
+            for item in fetched
         )
+        if len(fetched) < page_size:
+            break
+        page += 1
     return results
 
 

--- a/proot_distro/helpers/docker/search.py
+++ b/proot_distro/helpers/docker/search.py
@@ -25,47 +25,42 @@
 # therefore cannot be searched — Hub is the default registry anyway.
 #
 # image_architectures() is the second half: it reads a repository's
-# multi-arch manifest index from the registry so the search table can
-# list which CPU architectures each hit ships.
+# published tag metadata from the same hub.docker.com API, whose
+# images[] list names the OS and CPU architecture of every platform the
+# tag ships. One unauthenticated request answers what a registry token
+# dance plus a manifest fetch (and, for a single-architecture image, a
+# config-blob fetch) used to answer — and it answers for single-arch
+# images too, since the metadata lists an architecture per image.
 
 import json
 import urllib.parse
 import urllib.request
 
 from proot_distro.helpers.download import retry_http
-from proot_distro.helpers.docker.media import (
-    DOCKER_MANIFEST_LIST_MEDIA,
-    DOCKER_MANIFEST_MEDIA,
-    OCI_INDEX_MEDIA,
-    OCI_MANIFEST_MEDIA,
+from proot_distro.helpers.docker.refs import (
+    ARCH_TO_DOCKER,
+    DOCKER_TO_ARCH,
+    parse_image_ref,
 )
-from proot_distro.helpers.docker.refs import DOCKER_TO_ARCH, parse_image_ref
-from proot_distro.helpers.docker.transport import _ua, get_auth_token, opener
+from proot_distro.helpers.docker.transport import _ua, opener
 
 
 HUB_SEARCH_URL = "https://hub.docker.com/v2/search/repositories/"
 
 # Docker Hub caps a single search page at this many results; larger
 # limits are fetched by walking `page` until the limit is satisfied or
-# the API stops answering.
+# the API stops answering. The API answers HTTP 403 to any page past
+# the last one (in practice, past the second page of one hundred), so an
+# unbounded walk terminates exactly where a bounded one would.
 MAX_PAGE_SIZE = 100
 
-# Media types that describe a multi-architecture image index — the only
-# manifest kind whose entries carry a platform we can read an arch from.
-_INDEX_MEDIA_TYPES = frozenset({DOCKER_MANIFEST_LIST_MEDIA, OCI_INDEX_MEDIA})
-
-# The same Accept list as the pull pipeline, so the registry hands us an
-# index whenever the image ships one (single-arch images answer with their
-# plain manifest instead).
-_INDEX_ACCEPT = ", ".join([
-    OCI_INDEX_MEDIA,
-    DOCKER_MANIFEST_LIST_MEDIA,
-    OCI_MANIFEST_MEDIA,
-    DOCKER_MANIFEST_MEDIA,
-])
+# Published metadata for one repository's tag. A repository with no
+# 'latest' tag answers HTTP 404 — exactly the case the caller cannot
+# install, since `install <repo>` defaults to :latest.
+HUB_TAG_API = "https://hub.docker.com/v2/repositories/{}/tags/latest"
 
 
-def search_images(query: str, limit: int = 100) -> list:
+def search_images(query: str, limit: int = None) -> list:
     """Search Docker Hub for repositories matching *query*.
 
     Returns a list of result dicts carrying the fields `docker search`
@@ -76,16 +71,22 @@ def search_images(query: str, limit: int = 100) -> list:
 
     Docker Hub answers at most `MAX_PAGE_SIZE` repositories per page, so
     a *limit* beyond that walks the `page` parameter until the limit is
-    satisfied or the API stops answering.
+    satisfied or the API stops answering. With no *limit* (the default)
+    the walk continues until the API stops answering — every repository
+    Docker Hub will serve for the query.
     """
     query = (query or "").strip()
     if not query:
         return []
-    limit = max(1, int(limit))
     results = []
     page = 1
-    while len(results) < limit:
-        page_size = min(MAX_PAGE_SIZE, limit - len(results))
+    while limit is None or len(results) < limit:
+        if limit is None:
+            page_size = MAX_PAGE_SIZE
+        else:
+            page_size = min(MAX_PAGE_SIZE, max(1, int(limit)) - len(results))
+        if page_size <= 0:
+            break
         params = {"query": query, "page_size": page_size, "page": page}
         url = f"{HUB_SEARCH_URL}?{urllib.parse.urlencode(params)}"
         req = urllib.request.Request(url, headers=_ua())
@@ -94,7 +95,15 @@ def search_images(query: str, limit: int = 100) -> list:
             with opener().open(req) as resp:
                 return resp.read()
 
-        data = json.loads(retry_http(_attempt, what="Searching Docker Hub"))
+        try:
+            data = json.loads(retry_http(_attempt, what="Searching Docker Hub"))
+        except Exception:
+            # A page past the last one (Docker Hub answers HTTP 403)
+            # ends the walk with what we already have. A failure on the
+            # first page is a real network problem and must propagate.
+            if page == 1:
+                raise
+            break
         fetched = data.get("results", []) or []
         if not fetched:
             break
@@ -122,56 +131,58 @@ def search_images(query: str, limit: int = 100) -> list:
 def image_architectures(image_ref: str, insecure: bool = False) -> list:
     """Return the proot-distro arch names *image_ref*'s latest tag ships.
 
-    Search results are repositories, not tags, so the registry is always
-    probed for the 'latest' tag. The multi-arch manifest index is fetched
-    and each entry's platform is mapped back to a proot-distro
-    architecture name (unknown Docker arch names pass through unchanged).
+    Search results are repositories, not tags, so Docker Hub's tag API is
+    always asked about 'latest'. Its images[] metadata names the OS and
+    CPU architecture of every platform the tag ships — single-architecture
+    images included — and Docker arch names are mapped back to
+    proot-distro names, unknown ones passing through unchanged. A
+    repository with no 'latest' tag answers HTTP 404, which is exactly the
+    case the caller cannot install.
+
+    *insecure* is accepted for signature compatibility but ignored:
+    hub.docker.com is always reached over verified HTTPS.
 
     An empty list is returned whenever the answer cannot be determined —
-    the image is single-architecture (a plain manifest carries no
-    platform), the 'latest' tag does not exist, the repository is private,
-    or the network failed — so a search table never fails because one
-    repository refused to answer.
+    the 'latest' tag does not exist, the repository is private, the
+    network failed, or the registry is rate-limiting — so a search table
+    never fails because one repository refused to answer. Each lookup is
+    attempted once: a search resolving a page of repositories is
+    best-effort by design, and backing off five seconds per hit would
+    turn a rate-limited search into a crawl.
     """
-    registry, repo, _tag = parse_image_ref(image_ref)
-    try:
-        token, base = get_auth_token(repo, registry, insecure=insecure)
-    except Exception:
-        return []
-
-    headers = {**_ua(), "Accept": _INDEX_ACCEPT}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    req = urllib.request.Request(
-        f"{base}/v2/{repo}/manifests/latest", headers=headers
-    )
+    _registry, repo, _tag = parse_image_ref(image_ref)
+    req = urllib.request.Request(HUB_TAG_API.format(repo), headers=_ua())
 
     def _attempt():
-        with opener(insecure).open(req) as resp:
-            return resp.read(), resp.headers.get("Content-Type", "")
+        with opener().open(req) as resp:
+            return resp.read()
 
     try:
-        body, ct = retry_http(
-            _attempt, what=f"Fetching manifest for {image_ref}"
-        )
+        data = json.loads(retry_http(
+            _attempt, what=f"Fetching tags for {image_ref}",
+            max_retries=1,
+        ))
     except Exception:
-        return []
-    try:
-        data = json.loads(body)
-    except ValueError:
-        return []
-
-    ct = ct.split(";")[0].strip() or data.get("mediaType", "")
-    if ct not in _INDEX_MEDIA_TYPES or "manifests" not in data:
         return []
 
     archs = set()
-    for entry in data.get("manifests", []) or []:
-        platform = entry.get("platform", {}) or {}
-        if platform.get("os", "linux") != "linux":
+    for image in data.get("images", []) or []:
+        if image.get("os", "linux") != "linux":
             continue
-        docker_arch = platform.get("architecture")
-        if not docker_arch:
+        docker_arch = image.get("architecture")
+        if not docker_arch or docker_arch == "unknown":
             continue
         archs.add(DOCKER_TO_ARCH.get(docker_arch, docker_arch))
     return sorted(archs)
+
+
+# The CPU architectures proot-distro can install. image_architectures()
+# lets unknown Docker arch names (ppc64le, s390x, …) pass through
+# unchanged, so a hit that ships only those must not count as installable.
+INSTALLABLE_ARCHS = frozenset(ARCH_TO_DOCKER)
+
+
+def is_installable(architectures: list) -> bool:
+    """True when at least one of *architectures* is an arch proot-distro
+    can install."""
+    return bool(set(architectures) & INSTALLABLE_ARCHS)

--- a/proot_distro/parser.py
+++ b/proot_distro/parser.py
@@ -376,7 +376,7 @@ def _search(sub):
     p._pd_command = "search"
     p.add_argument("query", nargs="?", default=None, metavar="TERM")
     p.add_argument(
-        "--limit", dest="limit", type=int, default=100, metavar="N",
+        "--limit", dest="limit", type=int, default=None, metavar="N",
     )
     p.add_argument("-q", "--quiet", action="store_true")
     p.add_argument("-h", "--help", action="store_true")

--- a/proot_distro/parser.py
+++ b/proot_distro/parser.py
@@ -74,6 +74,7 @@ REQUIRED_ARGS = {
     "run":     [("container_name", "container name is not specified.")],
     "push":    [("image_ref", "image reference is not specified"
                  " (e.g. 'myrepo/myapp:1.0').")],
+    "search":  [("query", "search term is not specified.")],
 }
 
 
@@ -175,6 +176,7 @@ def build_parser() -> _PdArgumentParser:
     _sync(sub)
     _build(sub)
     _push(sub)
+    _search(sub)
     _run(sub)
     _ps(sub)
     _kill(sub)
@@ -361,6 +363,17 @@ def _push(sub):
     )
     p.add_argument(
         "--allow-insecure", dest="allow_insecure", action="store_true",
+    )
+    p.add_argument("-q", "--quiet", action="store_true")
+    p.add_argument("-h", "--help", action="store_true")
+
+
+def _search(sub):
+    p = sub.add_parser("search", add_help=False)
+    p._pd_command = "search"
+    p.add_argument("query", nargs="?", default=None, metavar="TERM")
+    p.add_argument(
+        "--limit", dest="limit", type=int, default=25, metavar="N",
     )
     p.add_argument("-q", "--quiet", action="store_true")
     p.add_argument("-h", "--help", action="store_true")

--- a/proot_distro/parser.py
+++ b/proot_distro/parser.py
@@ -373,7 +373,7 @@ def _search(sub):
     p._pd_command = "search"
     p.add_argument("query", nargs="?", default=None, metavar="TERM")
     p.add_argument(
-        "--limit", dest="limit", type=int, default=25, metavar="N",
+        "--limit", dest="limit", type=int, default=100, metavar="N",
     )
     p.add_argument("-q", "--quiet", action="store_true")
     p.add_argument("-h", "--help", action="store_true")

--- a/tests/integration/test_cli_dispatch.py
+++ b/tests/integration/test_cli_dispatch.py
@@ -68,3 +68,13 @@ def test_login_separator_inner_command(monkeypatch, capsys, builders):
     assert code == 0
     out = capsys.readouterr().out
     assert "echo" in out and "hi" in out
+
+
+def test_search_requires_term(monkeypatch, capsys):
+    assert _run(monkeypatch, ["search"]) == 1
+    assert "search term" in capsys.readouterr().err
+
+
+def test_search_quiet_does_not_set_global(monkeypatch):
+    _run(monkeypatch, ["search", "-q", "ubuntu"])
+    assert message.is_quiet() is False

--- a/tests/integration/test_login_get_proot_cmd.py
+++ b/tests/integration/test_login_get_proot_cmd.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from proot_distro.arch import get_device_cpu_arch
+from proot_distro.commands import login as login_mod
 from proot_distro.commands.login import command_login, _detect_dist_type
 from proot_distro.commands.login import proot_cmd
 from proot_distro.commands.run import command_run
@@ -236,3 +237,56 @@ def test_termux_type_login_applies_image_env(builders, capsys):
     assert exc.value.code == 0
     out = capsys.readouterr().out
     assert "FOO=frommanifest" in out
+
+
+def _captured_hostname(monkeypatch, builders, name, **over):
+    """Run command_login, recording the hostname passed to build_proot_args."""
+    captured = {}
+
+    def fake_build(**kw):
+        captured.update(kw)
+        return ["proot"]
+
+    monkeypatch.setattr(login_mod, "build_proot_args", fake_build)
+    with pytest.raises(SystemExit) as exc:
+        command_login(_login_args(name, **over))
+    assert exc.value.code == 0
+    return captured
+
+
+def test_default_hostname_is_container_name(builders, monkeypatch):
+    captured = _captured_hostname(monkeypatch, builders, "mybox", hostname=None)
+    assert captured["hostname"] == "mybox"
+
+
+def test_explicit_hostname_wins(builders, monkeypatch):
+    captured = _captured_hostname(monkeypatch, builders, "mybox",
+                                  hostname="customhost")
+    assert captured["hostname"] == "customhost"
+
+
+def test_empty_hostname_defaults_to_container_name(builders, monkeypatch):
+    captured = _captured_hostname(monkeypatch, builders, "mybox",
+                                  hostname="")
+    assert captured["hostname"] == "mybox"
+
+
+def test_run_default_hostname_is_container_name(builders, monkeypatch):
+    captured = {}
+
+    def fake_build(**kw):
+        captured.update(kw)
+        return ["proot"]
+
+    monkeypatch.setattr(login_mod, "build_proot_args", fake_build)
+    builders.make_container("runbox", arch=HOST_ARCH, manifest={
+        "image_config": {"config": {"Cmd": ["/bin/echo", "hi"]}},
+    })
+    args = SimpleNamespace(
+        container_name="runbox", run_args=[], get_proot_cmd=True,
+        work_dir=None, user="root",
+    )
+    with pytest.raises(SystemExit) as exc:
+        command_run(args)
+    assert exc.value.code == 0
+    assert captured["hostname"] == "runbox"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,230 @@
+# Unit tests for the programmatic interface (proot_distro.api), which runs
+# commands inside containers and reinstalls them without going through the
+# CLI. subprocess.run is stubbed so no real proot is ever spawned.
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from proot_distro import api
+from proot_distro.api import (
+    CommandError,
+    ContainerNotInstalled,
+    ProotDistroError,
+    ProotResult,
+    run,
+    reinstall,
+)
+from proot_distro.arch import get_device_cpu_arch
+from proot_distro.paths import container_manifest, container_rootfs
+
+
+HOST_ARCH = get_device_cpu_arch()
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Replace subprocess.run with a recorder; return (calls, set_result)."""
+    calls = []
+
+    def set_result(returncode=0, stdout=b"", stderr=b""):
+        nonlocal result
+        result = _FakeProc(returncode, stdout, stderr)
+
+    result = _FakeProc()
+    monkeypatch.setattr(
+        api.subprocess, "run",
+        lambda *a, **kw: (calls.append((a, kw)) or result),
+    )
+    return calls, set_result
+
+
+def test_run_returns_result_with_output(builders, fake_run):
+    builders.make_container("box", arch=HOST_ARCH)
+    _, set_result = fake_run
+    set_result(0, b"hello\n", b"")
+
+    res = run("box", ["sh", "-c", "echo hello"])
+
+    assert isinstance(res, ProotResult)
+    assert res.returncode == 0
+    assert res.stdout == b"hello\n"
+    assert res.ok
+
+
+def test_run_spawns_proot_with_guest_argv(builders, fake_run):
+    builders.make_container("box", arch=HOST_ARCH)
+    calls, _ = fake_run
+
+    run("box", ["echo", "hi"])
+
+    (proot_args,), kw = calls[0]
+    assert kw["env"] is not None
+    assert kw["stdout"] == api.subprocess.PIPE
+    assert proot_args[0] == "proot" or os.path.basename(proot_args[0]) == "proot"
+    assert f"--rootfs={container_rootfs('box')}" in proot_args
+    assert "--change-id=0:0" in proot_args
+    assert proot_args[-2:] == ["echo", "hi"]
+    # The child env is a fresh dict built like login's, not the host env.
+    assert "PATH" in kw["env"]
+
+
+def test_run_applies_user_bind_env_workdir(builders, fake_run):
+    builders.make_container("box", arch=HOST_ARCH, manifest={
+        "image_config": {"config": {"Env": ["FROMIMAGE=yes"]}},
+    })
+    calls, _ = fake_run
+
+    run("box", ["id"], user="tester", work_dir="/home/tester",
+        env=["FOO=bar"], bind=["/data/foo:/mnt/foo"])
+
+    (proot_args,), kw = calls[0]
+    assert "--change-id=1000:1000" in proot_args
+    assert "--cwd=/home/tester" in proot_args
+    assert "--bind=/data/foo:/mnt/foo" in proot_args
+    assert kw["env"]["FROMIMAGE"] == "yes"
+    assert kw["env"]["FOO"] == "bar"
+    assert kw["env"]["HOME"] == "/home/tester"
+
+
+def test_run_check_raises_on_nonzero(builders, fake_run):
+    builders.make_container("box", arch=HOST_ARCH)
+    _, set_result = fake_run
+    set_result(2, b"", b"boom")
+
+    with pytest.raises(CommandError) as exc:
+        run("box", ["false"], check=True)
+    assert "boom" in str(exc.value)
+
+
+def test_run_check_false_returns_nonzero(builders, fake_run):
+    builders.make_container("box", arch=HOST_ARCH)
+    _, set_result = fake_run
+    set_result(7, b"", b"")
+
+    res = run("box", ["false"])
+    assert res.returncode == 7
+    assert not res.ok
+
+
+def test_run_rejects_string_argv(builders, fake_run):
+    builders.make_container("box", arch=HOST_ARCH)
+    with pytest.raises(TypeError):
+        run("box", "echo hi")
+
+
+def test_run_rejects_empty_argv(builders, fake_run):
+    builders.make_container("box", arch=HOST_ARCH)
+    with pytest.raises(ValueError):
+        run("box", [])
+
+
+def test_run_missing_container_raises(fake_run):
+    with pytest.raises(ContainerNotInstalled):
+        run("not-installed", ["echo", "hi"])
+
+
+def test_run_invalid_name_raises(fake_run):
+    with pytest.raises(SystemExit):
+        run("bad name!", ["echo", "hi"])
+
+
+def test_run_missing_proot_binary_raises(builders, monkeypatch):
+    builders.make_container("box", arch=HOST_ARCH)
+
+    def boom(*a, **kw):
+        raise FileNotFoundError("no proot")
+
+    monkeypatch.setattr(api.subprocess, "run", boom)
+    with pytest.raises(ProotDistroError):
+        run("box", ["echo", "hi"])
+
+
+# ---------------------------------------------------------------------------
+# reinstall
+# ---------------------------------------------------------------------------
+
+def _manifest_data(image_ref="test:latest", arch=None):
+    return {"image_ref": image_ref, "arch": arch or HOST_ARCH,
+            "manifest": {"schemaVersion": 2, "layers": []},
+            "image_config": {"config": {}}}
+
+
+def test_reinstall_removes_rootfs_and_installs(builders, monkeypatch, capsys):
+    builders.make_container("box", arch=HOST_ARCH,
+                            manifest=_manifest_data("ubuntu:24.04"),
+                            files={"usr/bin/marker": b"old"})
+    install_calls = []
+
+    def fake_install(args):
+        install_calls.append(args)
+        os.makedirs(container_rootfs("box"), exist_ok=True)
+
+    monkeypatch.setattr(api, "command_install", fake_install)
+
+    assert reinstall("box") is None
+
+    assert install_calls
+    assert install_calls[0].image_ref == "ubuntu:24.04"
+    assert install_calls[0].custom_container_name == "box"
+    assert install_calls[0].override_arch == HOST_ARCH
+    # The old rootfs content was wiped before reinstall.
+    assert not os.path.exists(os.path.join(container_rootfs("box"),
+                                           "usr", "bin", "marker"))
+    # The manifest survives the reinstall.
+    assert os.path.isfile(container_manifest("box"))
+
+
+def test_reinstall_missing_container_raises():
+    with pytest.raises(ContainerNotInstalled):
+        reinstall("ghost")
+
+
+def test_reinstall_without_manifest_raises(builders):
+    builders.make_container("box", arch=HOST_ARCH, manifest=None)
+    with pytest.raises(ProotDistroError) as exc:
+        reinstall("box")
+    assert "no OCI manifest" in str(exc.value)
+
+
+def test_reinstall_bad_manifest_raises(builders):
+    builders.make_container("box", arch=HOST_ARCH, manifest=None)
+    with open(container_manifest("box"), "w") as fh:
+        fh.write("{ not json")
+    with pytest.raises(ProotDistroError):
+        reinstall("box")
+
+
+def test_reinstall_empty_image_ref_raises(builders):
+    builders.make_container("box", arch=HOST_ARCH,
+                            manifest=_manifest_data(image_ref=None))
+    with pytest.raises(ProotDistroError):
+        reinstall("box")
+
+
+def test_build_login_runtime_shared_with_cli(builders):
+    """The API resolves the same runtime dict the CLI login path uses."""
+    from proot_distro.commands.login import build_login_runtime
+
+    builders.make_container("box", arch=HOST_ARCH)
+    args = SimpleNamespace(
+        container_name="box", user="root", kernel=None, hostname=None,
+        work_dir="", redirect_ports=False, isolated=False, minimal=False,
+        shared_home=False, shared_tmp=False, shared_x11=False,
+        no_link2symlink=False, no_sysvipc=False, no_kill_on_exit=False,
+        bind=[], env=[], login_cmd=[], _run_inner=["/bin/echo", "x"],
+        emulator=None,
+    )
+    rt = build_login_runtime("box", args)
+    assert rt["inner"] == ["/bin/echo", "x"]
+    assert rt["proot_args"][-2:] == ["/bin/echo", "x"]
+    assert rt["rootfs"] == container_rootfs("box")

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -232,7 +232,7 @@ def test_search_parsing():
 def test_search_defaults():
     p = parser.build_parser()
     args, _ = p.parse_known_args(["search", "alpine"])
-    assert args.limit == 25
+    assert args.limit == 100
     assert args.quiet is False
 
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -79,6 +79,7 @@ def test_each_subcommand_parses():
         (["sync", "a", "b"], "sync"),
         (["build", "."], "build"),
         (["push", "me/app:1"], "push"),
+        (["search", "ubuntu"], "search"),
         (["run", "box"], "run"),
         (["login", "box"], "login"),
         (["kill", "box"], "kill"),
@@ -216,3 +217,39 @@ def test_required_args_for_switches_on_image_flag():
     # Every other command falls through to the static table.
     assert parser.required_args_for("install", SimpleNamespace()) == \
         parser.REQUIRED_ARGS["install"]
+
+
+def test_search_parsing():
+    p = parser.build_parser()
+    args, unknown = p.parse_known_args(["search", "ubuntu", "--limit", "10"])
+    assert args.command == "search"
+    assert args.query == "ubuntu"
+    assert args.limit == 10
+    assert args.quiet is False
+    assert unknown == []
+
+
+def test_search_defaults():
+    p = parser.build_parser()
+    args, _ = p.parse_known_args(["search", "alpine"])
+    assert args.limit == 25
+    assert args.quiet is False
+
+
+def test_search_quiet_flag():
+    p = parser.build_parser()
+    args, unknown = p.parse_known_args(["search", "-q", "ubuntu"])
+    assert args.query == "ubuntu"
+    assert args.quiet is True
+    assert unknown == []
+
+
+def test_search_missing_positional_is_none():
+    p = parser.build_parser()
+    args, _ = p.parse_known_args(["search"])
+    assert args.query is None  # nargs="?", validated later by REQUIRED_ARGS
+
+
+def test_search_required_args_table():
+    assert ("query",) == tuple(a for a, _ in parser.REQUIRED_ARGS["search"])
+    assert "search term" in parser.REQUIRED_ARGS["search"][0][1]

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -232,7 +232,7 @@ def test_search_parsing():
 def test_search_defaults():
     p = parser.build_parser()
     args, _ = p.parse_known_args(["search", "alpine"])
-    assert args.limit == 100
+    assert args.limit is None
     assert args.quiet is False
 
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -3,6 +3,7 @@
 
 import io
 import json
+import urllib.parse
 from types import SimpleNamespace
 
 import pytest
@@ -106,6 +107,49 @@ def test_search_images_missing_results_key(monkeypatch):
     assert search_mod.search_images("nope") == []
 
 
+def test_search_images_paginates_beyond_docker_hub_page_cap(monkeypatch):
+    captured = []
+
+    def fake_open(req, *a, **k):
+        qs = urllib.parse.parse_qs(
+            urllib.parse.urlparse(req.full_url).query
+        )
+        page = int(qs["page"][0])
+        page_size = int(qs["page_size"][0])
+        captured.append((page, page_size))
+        return _FakeResp({"results": [
+            {"name": f"lib/img-{page}-{i}", "description": ""}
+            for i in range(page_size)
+        ]})
+
+    _patch_opener(monkeypatch, fake_open)
+    results = search_mod.search_images("ubuntu", limit=250)
+    assert len(results) == 250
+    assert captured == [(1, 100), (2, 100), (3, 50)]
+
+
+def test_search_images_stops_when_a_page_comes_back_short(monkeypatch):
+    captured = []
+
+    def fake_open(req, *a, **k):
+        qs = urllib.parse.parse_qs(
+            urllib.parse.urlparse(req.full_url).query
+        )
+        page = int(qs["page"][0])
+        page_size = int(qs["page_size"][0])
+        captured.append(page)
+        n = page_size if page == 1 else page_size // 2
+        return _FakeResp({"results": [
+            {"name": f"lib/img-{page}-{i}", "description": ""}
+            for i in range(n)
+        ]})
+
+    _patch_opener(monkeypatch, fake_open)
+    results = search_mod.search_images("ubuntu", limit=250)
+    assert len(results) == 150
+    assert captured == [1, 2]
+
+
 # ----- image_architectures ------------------------------------------------
 
 class _FakeManifestResp:
@@ -191,14 +235,14 @@ def test_image_architectures_manifest_error_is_empty(monkeypatch):
 # ----- command ------------------------------------------------------------
 
 def _cmd_args(**over):
-    base = dict(query="ubuntu", limit=25, quiet=False)
+    base = dict(query="ubuntu", limit=100, quiet=False)
     base.update(over)
     return SimpleNamespace(**base)
 
 
 def test_command_search_quiet_prints_names(monkeypatch, capsys):
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=25: _SAMPLE_RESULTS)
+                        lambda q, limit=100: _SAMPLE_RESULTS)
     search_cmd.command_search(_cmd_args(quiet=True))
     out = capsys.readouterr().out
     assert out.splitlines() == ["library/ubuntu", "myuser/ubuntu-lite"]
@@ -206,7 +250,7 @@ def test_command_search_quiet_prints_names(monkeypatch, capsys):
 
 def test_command_search_table(monkeypatch, capsys):
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=25: _SAMPLE_RESULTS)
+                        lambda q, limit=100: _SAMPLE_RESULTS)
     monkeypatch.setattr(search_cmd, "image_architectures",
                         lambda ref, insecure=False: ["aarch64", "x86_64"])
     monkeypatch.setattr(search_cmd, "terminal_width", lambda default=80: 120)
@@ -230,7 +274,7 @@ def test_command_search_resolves_architectures(monkeypatch, capsys):
                 "myuser/ubuntu-lite": ["arm"]}[ref]
 
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=25: _SAMPLE_RESULTS)
+                        lambda q, limit=100: _SAMPLE_RESULTS)
     monkeypatch.setattr(search_cmd, "image_architectures", fake_arch)
     monkeypatch.setattr(search_cmd, "terminal_width", lambda default=80: 120)
     search_cmd.command_search(_cmd_args())
@@ -244,7 +288,7 @@ def test_command_search_quiet_skips_architectures(monkeypatch, capsys):
         raise AssertionError("quiet search must not fetch architectures")
 
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=25: _SAMPLE_RESULTS)
+                        lambda q, limit=100: _SAMPLE_RESULTS)
     monkeypatch.setattr(search_cmd, "image_architectures", boom)
     search_cmd.command_search(_cmd_args(quiet=True))
     out = capsys.readouterr().out
@@ -253,7 +297,7 @@ def test_command_search_quiet_skips_architectures(monkeypatch, capsys):
 
 def test_command_search_unknown_arch_question_mark(monkeypatch, capsys):
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=25: _SAMPLE_RESULTS)
+                        lambda q, limit=100: _SAMPLE_RESULTS)
     monkeypatch.setattr(search_cmd, "image_architectures",
                         lambda ref, insecure=False: [])
     search_cmd.command_search(_cmd_args())
@@ -262,7 +306,7 @@ def test_command_search_unknown_arch_question_mark(monkeypatch, capsys):
 
 
 def test_command_search_empty_results(monkeypatch, capsys):
-    monkeypatch.setattr(search_cmd, "search_images", lambda q, limit=25: [])
+    monkeypatch.setattr(search_cmd, "search_images", lambda q, limit=100: [])
     search_cmd.command_search(_cmd_args(query="zzzznone"))
     err = capsys.readouterr().err
     assert "No results" in err
@@ -276,7 +320,7 @@ def test_command_search_missing_query(capsys):
 
 
 def test_command_search_network_error(monkeypatch, capsys):
-    def boom(q, limit=25):
+    def boom(q, limit=100):
         raise __import__("urllib.error").error.URLError("offline")
 
     monkeypatch.setattr(search_cmd, "search_images", boom)
@@ -289,7 +333,7 @@ def test_command_search_network_error(monkeypatch, capsys):
 def test_command_search_limit_passed_through(monkeypatch):
     captured = {}
 
-    def fake_search(q, limit=25):
+    def fake_search(q, limit=100):
         captured["q"] = q
         captured["limit"] = limit
         return []

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,0 +1,306 @@
+# Tests for `proot-distro search` — the Docker Hub search helper and the
+# command handler (table / quiet / empty / error paths). Network is mocked.
+
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from proot_distro.helpers.docker import search as search_mod
+from proot_distro.commands import search as search_cmd
+from proot_distro.helpers import download
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch):
+    monkeypatch.setattr(download.time, "sleep", lambda *a, **k: None)
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._buf = io.BytesIO(json.dumps(payload).encode())
+
+    def read(self, *a):
+        return self._buf.read(*a)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeOpener:
+    def __init__(self, fn):
+        self._fn = fn
+
+    def open(self, req, *a, **k):
+        return self._fn(req, *a, **k)
+
+
+def _patch_opener(monkeypatch, fn):
+    monkeypatch.setattr(search_mod, "opener",
+                        lambda insecure=False: _FakeOpener(fn))
+
+
+_SAMPLE_RESULTS = [
+    {"name": "library/ubuntu", "description": "Ubuntu is a Debian-based "
+     "Linux operating system.", "star_count": 15266, "is_official": True,
+     "is_automated": False, "pull_count": 123456789},
+    {"name": "myuser/ubuntu-lite", "description": "Minimal Ubuntu.",
+     "star_count": 12, "is_official": False, "is_automated": True,
+     "pull_count": 9000},
+]
+
+
+# ----- helper -------------------------------------------------------------
+
+def test_search_images_encodes_query_and_limit(monkeypatch):
+    captured = {}
+
+    def fake_open(req, *a, **k):
+        captured["url"] = req.full_url
+        return _FakeResp({"count": 1, "results": _SAMPLE_RESULTS})
+
+    _patch_opener(monkeypatch, fake_open)
+    results = search_mod.search_images("ubuntu", limit=10)
+    assert results == _SAMPLE_RESULTS
+    assert "query=ubuntu" in captured["url"]
+    assert "page_size=10" in captured["url"]
+
+
+def test_search_images_empty_query_no_request(monkeypatch):
+    called = []
+
+    def fake_open(req, *a, **k):
+        called.append(req)
+        raise AssertionError("no request expected")
+
+    _patch_opener(monkeypatch, fake_open)
+    assert search_mod.search_images("   ") == []
+    assert search_mod.search_images(None) == []
+    assert called == []
+
+
+def test_search_images_retries_transient_then_succeeds(monkeypatch):
+    calls = []
+
+    def fake_open(req, *a, **k):
+        calls.append(req.full_url)
+        if len(calls) < 3:
+            raise __import__("urllib.error").error.URLError("connection reset")
+        return _FakeResp({"results": _SAMPLE_RESULTS})
+
+    _patch_opener(monkeypatch, fake_open)
+    results = search_mod.search_images("ubuntu")
+    assert len(calls) == 3
+    assert results == _SAMPLE_RESULTS
+
+
+def test_search_images_missing_results_key(monkeypatch):
+    def fake_open(req, *a, **k):
+        return _FakeResp({})
+
+    _patch_opener(monkeypatch, fake_open)
+    assert search_mod.search_images("nope") == []
+
+
+# ----- image_architectures ------------------------------------------------
+
+class _FakeManifestResp:
+    def __init__(self, payload, content_type):
+        self._buf = io.BytesIO(json.dumps(payload).encode())
+        self.headers = {"Content-Type": content_type}
+
+    def read(self, *a):
+        return self._buf.read(*a)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _patch_manifest_io(monkeypatch, resp):
+    monkeypatch.setattr(
+        search_mod, "get_auth_token",
+        lambda repo, registry="", insecure=False: (
+            "tok", "https://registry-1.docker.io"
+        ),
+    )
+    monkeypatch.setattr(search_mod, "opener",
+                        lambda insecure=False: _FakeOpener(
+                            lambda req, *a, **k: resp
+                        ))
+
+
+def test_image_architectures_from_index(monkeypatch):
+    index = {
+        "mediaType":
+            "application/vnd.docker.distribution.manifest.list.v2+json",
+        "manifests": [
+            {"platform": {"os": "linux", "architecture": "amd64"}},
+            {"platform": {"os": "linux", "architecture": "arm64"}},
+            {"platform": {"os": "linux", "architecture": "arm",
+                          "variant": "v7"}},
+            {"platform": {"os": "linux", "architecture": "ppc64le"}},
+            {"platform": {"os": "windows", "architecture": "amd64"}},
+            {"platform": {"os": "linux"}},
+        ],
+    }
+    _patch_manifest_io(monkeypatch, _FakeManifestResp(
+        index, "application/vnd.docker.distribution.manifest.list.v2+json"))
+    assert search_mod.image_architectures("library/ubuntu") == \
+        ["aarch64", "arm", "ppc64le", "x86_64"]
+
+
+def test_image_architectures_from_content_type_header(monkeypatch):
+    index = {"manifests": [
+        {"platform": {"os": "linux", "architecture": "amd64"}},
+    ]}
+    _patch_manifest_io(monkeypatch, _FakeManifestResp(
+        index, "application/vnd.oci.image.index.v1+json; charset=utf-8"))
+    assert search_mod.image_architectures("library/busybox") == ["x86_64"]
+
+
+def test_image_architectures_single_manifest_is_empty(monkeypatch):
+    single = {"mediaType":
+              "application/vnd.docker.distribution.manifest.v2+json",
+              "layers": [{"digest": "sha256:abc"}]}
+    _patch_manifest_io(monkeypatch, _FakeManifestResp(
+        single, "application/vnd.docker.distribution.manifest.v2+json"))
+    assert search_mod.image_architectures("library/single") == []
+
+
+def test_image_architectures_network_error_is_empty(monkeypatch):
+    def boom(repo, registry="", insecure=False):
+        raise __import__("urllib.error").error.URLError("offline")
+
+    monkeypatch.setattr(search_mod, "get_auth_token", boom)
+    assert search_mod.image_architectures("myuser/secret") == []
+
+
+def test_image_architectures_manifest_error_is_empty(monkeypatch):
+    _patch_manifest_io(monkeypatch, _FakeManifestResp(
+        {}, "application/json"))
+    assert search_mod.image_architectures("library/nope") == []
+
+
+# ----- command ------------------------------------------------------------
+
+def _cmd_args(**over):
+    base = dict(query="ubuntu", limit=25, quiet=False)
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_command_search_quiet_prints_names(monkeypatch, capsys):
+    monkeypatch.setattr(search_cmd, "search_images",
+                        lambda q, limit=25: _SAMPLE_RESULTS)
+    search_cmd.command_search(_cmd_args(quiet=True))
+    out = capsys.readouterr().out
+    assert out.splitlines() == ["library/ubuntu", "myuser/ubuntu-lite"]
+
+
+def test_command_search_table(monkeypatch, capsys):
+    monkeypatch.setattr(search_cmd, "search_images",
+                        lambda q, limit=25: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures",
+                        lambda ref, insecure=False: ["aarch64", "x86_64"])
+    monkeypatch.setattr(search_cmd, "terminal_width", lambda default=80: 120)
+    search_cmd.command_search(_cmd_args())
+    err = capsys.readouterr().err
+    assert "NAME" in err and "DESCRIPTION" in err and "STARS" in err
+    assert "ARCH" in err
+    assert "[OK]" in err          # official / automated flags rendered
+    assert "library/ubuntu" in err
+    assert "myuser/ubuntu-lite" in err
+    assert "aarch64/x86_64" in err
+    assert "Resolving architectures" in err
+
+
+def test_command_search_resolves_architectures(monkeypatch, capsys):
+    captured = []
+
+    def fake_arch(ref, insecure=False):
+        captured.append(ref)
+        return {"library/ubuntu": ["x86_64", "arm64"],
+                "myuser/ubuntu-lite": ["arm"]}[ref]
+
+    monkeypatch.setattr(search_cmd, "search_images",
+                        lambda q, limit=25: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures", fake_arch)
+    monkeypatch.setattr(search_cmd, "terminal_width", lambda default=80: 120)
+    search_cmd.command_search(_cmd_args())
+    assert captured == ["library/ubuntu", "myuser/ubuntu-lite"]
+    err = capsys.readouterr().err
+    assert "x86_64/arm64" in err and "arm" in err
+
+
+def test_command_search_quiet_skips_architectures(monkeypatch, capsys):
+    def boom(ref, insecure=False):
+        raise AssertionError("quiet search must not fetch architectures")
+
+    monkeypatch.setattr(search_cmd, "search_images",
+                        lambda q, limit=25: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures", boom)
+    search_cmd.command_search(_cmd_args(quiet=True))
+    out = capsys.readouterr().out
+    assert out.splitlines() == ["library/ubuntu", "myuser/ubuntu-lite"]
+
+
+def test_command_search_unknown_arch_question_mark(monkeypatch, capsys):
+    monkeypatch.setattr(search_cmd, "search_images",
+                        lambda q, limit=25: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures",
+                        lambda ref, insecure=False: [])
+    search_cmd.command_search(_cmd_args())
+    err = capsys.readouterr().err
+    assert "?" in err
+
+
+def test_command_search_empty_results(monkeypatch, capsys):
+    monkeypatch.setattr(search_cmd, "search_images", lambda q, limit=25: [])
+    search_cmd.command_search(_cmd_args(query="zzzznone"))
+    err = capsys.readouterr().err
+    assert "No results" in err
+
+
+def test_command_search_missing_query(capsys):
+    with pytest.raises(SystemExit) as exc:
+        search_cmd.command_search(_cmd_args(query=None))
+    assert exc.value.code == 1
+    assert "search term" in capsys.readouterr().err
+
+
+def test_command_search_network_error(monkeypatch, capsys):
+    def boom(q, limit=25):
+        raise __import__("urllib.error").error.URLError("offline")
+
+    monkeypatch.setattr(search_cmd, "search_images", boom)
+    with pytest.raises(SystemExit) as exc:
+        search_cmd.command_search(_cmd_args())
+    assert exc.value.code == 1
+    assert "Network error" in capsys.readouterr().err
+
+
+def test_command_search_limit_passed_through(monkeypatch):
+    captured = {}
+
+    def fake_search(q, limit=25):
+        captured["q"] = q
+        captured["limit"] = limit
+        return []
+
+    monkeypatch.setattr(search_cmd, "search_images", fake_search)
+    search_cmd.command_search(_cmd_args(query="alpine", limit=7))
+    assert captured == {"q": "alpine", "limit": 7}
+
+
+def test_ellipsize_truncates():
+    assert search_cmd._ellipsize("short", 20) == "short"
+    assert search_cmd._ellipsize("a long description here", 12) == \
+        "a long desc…"
+    assert search_cmd._ellipsize("abc", 1) == "a"

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -123,9 +123,71 @@ def test_search_images_paginates_beyond_docker_hub_page_cap(monkeypatch):
         ]})
 
     _patch_opener(monkeypatch, fake_open)
-    results = search_mod.search_images("ubuntu", limit=250)
-    assert len(results) == 250
-    assert captured == [(1, 100), (2, 100), (3, 50)]
+    results = search_mod.search_images("ubuntu", limit=150)
+    assert len(results) == 150
+    assert captured == [(1, 100), (2, 50)]
+
+
+def test_search_images_unlimited_walks_until_api_stops(monkeypatch):
+    """The default (no limit) fetches every repository the API will
+    serve; a 403 on the page past the last one ends the walk with what
+    we have instead of failing the search."""
+    captured = []
+
+    def fake_open(req, *a, **k):
+        qs = urllib.parse.parse_qs(
+            urllib.parse.urlparse(req.full_url).query
+        )
+        page = int(qs["page"][0])
+        page_size = int(qs["page_size"][0])
+        captured.append((page, page_size))
+        if page > 2:
+            raise __import__("urllib.error").error.HTTPError(
+                req.full_url, 403, "Forbidden", {}, None)
+        return _FakeResp({"results": [
+            {"name": f"lib/img-{page}-{i}", "description": ""}
+            for i in range(page_size)
+        ]})
+
+    _patch_opener(monkeypatch, fake_open)
+    results = search_mod.search_images("ubuntu")
+    assert len(results) == 200
+    assert captured == [(1, 100), (2, 100), (3, 100)]
+
+
+def test_search_images_unlimited_stops_on_short_page(monkeypatch):
+    """With no limit, a short page — not just an HTTP error — ends the
+    walk; every result the API has given so far is kept."""
+    captured = []
+
+    def fake_open(req, *a, **k):
+        qs = urllib.parse.parse_qs(
+            urllib.parse.urlparse(req.full_url).query
+        )
+        page = int(qs["page"][0])
+        page_size = int(qs["page_size"][0])
+        captured.append(page)
+        n = page_size if page == 1 else 50
+        return _FakeResp({"results": [
+            {"name": f"lib/img-{page}-{i}", "description": ""}
+            for i in range(n)
+        ]})
+
+    _patch_opener(monkeypatch, fake_open)
+    results = search_mod.search_images("ubuntu")
+    assert len(results) == 150
+    assert captured == [1, 2]
+
+
+def test_search_images_first_page_error_propagates(monkeypatch):
+    """A failure on the first page is a real network problem and must
+    reach the caller, not be swallowed as 'end of results'."""
+    def boom(req, *a, **k):
+        raise __import__("urllib.error").error.URLError("offline")
+
+    _patch_opener(monkeypatch, boom)
+    with pytest.raises(__import__("urllib.error").error.URLError):
+        search_mod.search_images("ubuntu")
 
 
 def test_search_images_stops_when_a_page_comes_back_short(monkeypatch):
@@ -152,10 +214,11 @@ def test_search_images_stops_when_a_page_comes_back_short(monkeypatch):
 
 # ----- image_architectures ------------------------------------------------
 
-class _FakeManifestResp:
-    def __init__(self, payload, content_type):
-        self._buf = io.BytesIO(json.dumps(payload).encode())
-        self.headers = {"Content-Type": content_type}
+class _FakeRawResp:
+    """A response whose body is *raw* bytes — for non-JSON payloads."""
+
+    def __init__(self, raw):
+        self._buf = io.BytesIO(raw)
 
     def read(self, *a):
         return self._buf.read(*a)
@@ -167,82 +230,103 @@ class _FakeManifestResp:
         return False
 
 
-def _patch_manifest_io(monkeypatch, resp):
-    monkeypatch.setattr(
-        search_mod, "get_auth_token",
-        lambda repo, registry="", insecure=False: (
-            "tok", "https://registry-1.docker.io"
-        ),
-    )
+def _patch_tag_api(monkeypatch, fn):
     monkeypatch.setattr(search_mod, "opener",
-                        lambda insecure=False: _FakeOpener(
-                            lambda req, *a, **k: resp
-                        ))
+                        lambda insecure=False: _FakeOpener(fn))
 
 
-def test_image_architectures_from_index(monkeypatch):
-    index = {
-        "mediaType":
-            "application/vnd.docker.distribution.manifest.list.v2+json",
-        "manifests": [
-            {"platform": {"os": "linux", "architecture": "amd64"}},
-            {"platform": {"os": "linux", "architecture": "arm64"}},
-            {"platform": {"os": "linux", "architecture": "arm",
-                          "variant": "v7"}},
-            {"platform": {"os": "linux", "architecture": "ppc64le"}},
-            {"platform": {"os": "windows", "architecture": "amd64"}},
-            {"platform": {"os": "linux"}},
-        ],
-    }
-    _patch_manifest_io(monkeypatch, _FakeManifestResp(
-        index, "application/vnd.docker.distribution.manifest.list.v2+json"))
+def _tag_images(*archs):
+    """Turn ("amd64", "linux", None) tuples into a tag-API images list."""
+    return [
+        {"architecture": a, "os": o, "variant": v} for a, o, v in archs
+    ]
+
+
+def test_image_architectures_from_tag_api(monkeypatch):
+    payload = {"name": "latest", "images": _tag_images(
+        ("amd64", "linux", None),
+        ("arm", "linux", "v7"),
+        ("arm64", "linux", "v8"),
+        ("ppc64le", "linux", None),
+        ("amd64", "windows", None),     # not linux: skipped
+        ("unknown", "unknown", None),   # Docker Hub placeholder: skipped
+        ("386", "linux", None),
+    )}
+    _patch_tag_api(monkeypatch, lambda req, *a, **k: _FakeResp(payload))
     assert search_mod.image_architectures("library/ubuntu") == \
-        ["aarch64", "arm", "ppc64le", "x86_64"]
+        ["aarch64", "arm", "i686", "ppc64le", "x86_64"]
 
 
-def test_image_architectures_from_content_type_header(monkeypatch):
-    index = {"manifests": [
-        {"platform": {"os": "linux", "architecture": "amd64"}},
-    ]}
-    _patch_manifest_io(monkeypatch, _FakeManifestResp(
-        index, "application/vnd.oci.image.index.v1+json; charset=utf-8"))
-    assert search_mod.image_architectures("library/busybox") == ["x86_64"]
+def test_image_architectures_single_architecture(monkeypatch):
+    payload = {"name": "latest", "images": _tag_images(
+        ("amd64", "linux", None),
+    )}
+    _patch_tag_api(monkeypatch, lambda req, *a, **k: _FakeResp(payload))
+    assert search_mod.image_architectures("library/ubuntu-old") == ["x86_64"]
 
 
-def test_image_architectures_single_manifest_is_empty(monkeypatch):
-    single = {"mediaType":
-              "application/vnd.docker.distribution.manifest.v2+json",
-              "layers": [{"digest": "sha256:abc"}]}
-    _patch_manifest_io(monkeypatch, _FakeManifestResp(
-        single, "application/vnd.docker.distribution.manifest.v2+json"))
-    assert search_mod.image_architectures("library/single") == []
+def test_image_architectures_missing_latest_tag(monkeypatch):
+    def http404(req, *a, **k):
+        raise __import__("urllib.error").error.HTTPError(
+            req.full_url, 404, "Not Found", {}, None)
+
+    _patch_tag_api(monkeypatch, http404)
+    assert search_mod.image_architectures("myuser/no-latest") == []
 
 
 def test_image_architectures_network_error_is_empty(monkeypatch):
-    def boom(repo, registry="", insecure=False):
+    def boom(req, *a, **k):
         raise __import__("urllib.error").error.URLError("offline")
 
-    monkeypatch.setattr(search_mod, "get_auth_token", boom)
+    _patch_tag_api(monkeypatch, boom)
     assert search_mod.image_architectures("myuser/secret") == []
 
 
-def test_image_architectures_manifest_error_is_empty(monkeypatch):
-    _patch_manifest_io(monkeypatch, _FakeManifestResp(
-        {}, "application/json"))
+def test_image_architectures_malformed_body(monkeypatch):
+    _patch_tag_api(monkeypatch,
+                   lambda req, *a, **k: _FakeRawResp(b"not json at all"))
+    assert search_mod.image_architectures("library/broken") == []
+
+
+def test_image_architectures_no_images_key(monkeypatch):
+    _patch_tag_api(monkeypatch, lambda req, *a, **k: _FakeResp({}))
     assert search_mod.image_architectures("library/nope") == []
+
+
+def test_image_architectures_url_is_the_latest_tag_endpoint(monkeypatch):
+    captured = []
+
+    def fake_open(req, *a, **k):
+        captured.append(req.full_url)
+        return _FakeResp({"images": _tag_images(("amd64", "linux", None))})
+
+    _patch_tag_api(monkeypatch, fake_open)
+    search_mod.image_architectures("myuser/img")
+    assert captured == [
+        "https://hub.docker.com/v2/repositories/myuser/img/tags/latest"
+    ]
+
+
+def test_is_installable():
+    assert search_mod.is_installable(["x86_64", "aarch64"])
+    assert search_mod.is_installable(["ppc64le", "arm"])
+    assert not search_mod.is_installable([])
+    assert not search_mod.is_installable(["ppc64le", "s390x"])
 
 
 # ----- command ------------------------------------------------------------
 
 def _cmd_args(**over):
-    base = dict(query="ubuntu", limit=100, quiet=False)
+    base = dict(query="ubuntu", limit=200, quiet=False)
     base.update(over)
     return SimpleNamespace(**base)
 
 
 def test_command_search_quiet_prints_names(monkeypatch, capsys):
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=100: _SAMPLE_RESULTS)
+                        lambda q, limit=200: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures",
+                        lambda ref, insecure=False: ["aarch64", "x86_64"])
     search_cmd.command_search(_cmd_args(quiet=True))
     out = capsys.readouterr().out
     assert out.splitlines() == ["library/ubuntu", "myuser/ubuntu-lite"]
@@ -250,7 +334,7 @@ def test_command_search_quiet_prints_names(monkeypatch, capsys):
 
 def test_command_search_table(monkeypatch, capsys):
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=100: _SAMPLE_RESULTS)
+                        lambda q, limit=200: _SAMPLE_RESULTS)
     monkeypatch.setattr(search_cmd, "image_architectures",
                         lambda ref, insecure=False: ["aarch64", "x86_64"])
     monkeypatch.setattr(search_cmd, "terminal_width", lambda default=80: 120)
@@ -262,7 +346,7 @@ def test_command_search_table(monkeypatch, capsys):
     assert "library/ubuntu" in err
     assert "myuser/ubuntu-lite" in err
     assert "aarch64/x86_64" in err
-    assert "Resolving architectures" in err
+    assert "Resolving architectures" not in err
 
 
 def test_command_search_resolves_architectures(monkeypatch, capsys):
@@ -274,7 +358,7 @@ def test_command_search_resolves_architectures(monkeypatch, capsys):
                 "myuser/ubuntu-lite": ["arm"]}[ref]
 
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=100: _SAMPLE_RESULTS)
+                        lambda q, limit=200: _SAMPLE_RESULTS)
     monkeypatch.setattr(search_cmd, "image_architectures", fake_arch)
     monkeypatch.setattr(search_cmd, "terminal_width", lambda default=80: 120)
     search_cmd.command_search(_cmd_args())
@@ -283,33 +367,69 @@ def test_command_search_resolves_architectures(monkeypatch, capsys):
     assert "x86_64/arm64" in err and "arm" in err
 
 
-def test_command_search_quiet_skips_architectures(monkeypatch, capsys):
-    def boom(ref, insecure=False):
-        raise AssertionError("quiet search must not fetch architectures")
-
+def test_command_search_quiet_resolves_and_filters(monkeypatch, capsys):
+    """--quiet must resolve architectures too, so the names piped into
+    `install` are only installable images."""
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=100: _SAMPLE_RESULTS)
-    monkeypatch.setattr(search_cmd, "image_architectures", boom)
+                        lambda q, limit=200: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures",
+                        lambda ref, insecure=False: {
+                            "library/ubuntu": ["x86_64"],
+                            "myuser/ubuntu-lite": [],
+                        }[ref])
     search_cmd.command_search(_cmd_args(quiet=True))
     out = capsys.readouterr().out
-    assert out.splitlines() == ["library/ubuntu", "myuser/ubuntu-lite"]
+    assert out.splitlines() == ["library/ubuntu"]
 
 
-def test_command_search_unknown_arch_question_mark(monkeypatch, capsys):
+def test_command_search_drops_unknown_arch(monkeypatch, capsys):
     monkeypatch.setattr(search_cmd, "search_images",
-                        lambda q, limit=100: _SAMPLE_RESULTS)
+                        lambda q, limit=200: _SAMPLE_RESULTS)
     monkeypatch.setattr(search_cmd, "image_architectures",
                         lambda ref, insecure=False: [])
     search_cmd.command_search(_cmd_args())
     err = capsys.readouterr().err
-    assert "?" in err
+    assert "?" not in err
+    assert "No installable images" in err
+
+
+def test_command_search_drops_unsupported_arch_only(monkeypatch, capsys):
+    """A hit shipping only architectures proot-distro cannot install is
+    dropped; one with a single supported arch is kept."""
+    monkeypatch.setattr(search_cmd, "search_images",
+                        lambda q, limit=200: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures",
+                        lambda ref, insecure=False: {
+                            "library/ubuntu": ["ppc64le", "x86_64"],
+                            "myuser/ubuntu-lite": ["s390x"],
+                        }[ref])
+    monkeypatch.setattr(search_cmd, "terminal_width", lambda default=80: 120)
+    search_cmd.command_search(_cmd_args())
+    err = capsys.readouterr().err
+    assert "library/ubuntu" in err
+    assert "myuser/ubuntu-lite" not in err
+    assert "ppc64le/x86_64" in err
+    assert "s390x" not in err
+
+
+def test_command_search_drop_note_logged(monkeypatch, capsys):
+    monkeypatch.setattr(search_cmd, "search_images",
+                        lambda q, limit=200: _SAMPLE_RESULTS)
+    monkeypatch.setattr(search_cmd, "image_architectures",
+                        lambda ref, insecure=False: {
+                            "library/ubuntu": ["x86_64"],
+                            "myuser/ubuntu-lite": [],
+                        }[ref])
+    search_cmd.command_search(_cmd_args(quiet=True))
+    err = capsys.readouterr().err
+    assert "Dropped 1 image(s)" in err
 
 
 def test_command_search_empty_results(monkeypatch, capsys):
-    monkeypatch.setattr(search_cmd, "search_images", lambda q, limit=100: [])
+    monkeypatch.setattr(search_cmd, "search_images", lambda q, limit=200: [])
     search_cmd.command_search(_cmd_args(query="zzzznone"))
     err = capsys.readouterr().err
-    assert "No results" in err
+    assert "No installable images" in err
 
 
 def test_command_search_missing_query(capsys):
@@ -320,7 +440,7 @@ def test_command_search_missing_query(capsys):
 
 
 def test_command_search_network_error(monkeypatch, capsys):
-    def boom(q, limit=100):
+    def boom(q, limit=200):
         raise __import__("urllib.error").error.URLError("offline")
 
     monkeypatch.setattr(search_cmd, "search_images", boom)
@@ -333,7 +453,7 @@ def test_command_search_network_error(monkeypatch, capsys):
 def test_command_search_limit_passed_through(monkeypatch):
     captured = {}
 
-    def fake_search(q, limit=100):
+    def fake_search(q, limit=200):
         captured["q"] = q
         captured["limit"] = limit
         return []


### PR DESCRIPTION
## Summary

Updates the fork to current upstream (v5.6.0 + subsequent fixes, `1669775`) and completes the `search` command work:

- **Unlimited results.** `--limit` no longer defaults to 100. A search walks Docker Hub's `page` parameter until the API stops answering (it replies HTTP 403 past the last page — a non-retryable error — which ends the walk with what was already fetched), so a search returns every repository the API will serve for the query. `--limit N` still caps the fetch.
- **Only installable images.** The ARCH column is resolved from each repository's published tag metadata (`hub.docker.com/v2/repositories/<repo>/tags/latest`) instead of a registry-token + manifest-index dance. The tag metadata names the platform of every image the tag ships, so single-architecture images now report their arch instead of `?`. A hit whose architecture cannot be determined — or that ships only architectures proot-distro cannot install (ppc64le, s390x, …) — is dropped from the results, `--quiet` included, so every name printed is a valid `install` target.
- **Quieter output.** The verbose `Resolving architectures for N image(s)...` notice is gone.

## Behaviour notes

- `--quiet` now resolves architectures too (names must be installable to be worth piping into `install`).
- The end-of-results HTTP 403 is not retried (`is_retryable_http_error` treats client errors as deterministic), so the unbounded walk terminates immediately rather than after 5×5s back-offs.
- Per-repository arch lookups are attempted once, so a rate-limited search degrades to dropping hits, not a crawl.

## Tests

- `tests/unit/test_search.py`: pagination (bounded + unbounded walk, short-page and 403 termination, first-page errors propagate), tag-metadata arch resolution (multi-arch, single-arch, missing `latest` → 404, malformed bodies, exact endpoint URL), `is_installable`, and command-level filtering/dropping for both table and `--quiet` output.
- `tests/unit/test_parser.py`: `--limit` default is now `None`.

Verified: 578 unit tests pass (6 pre-existing failures are environment-specific to running the suite on an Android/proot host and fail identically on the clean tree).